### PR TITLE
Add guild ID to message.

### DIFF
--- a/src/Discord/Types/Channel.hs
+++ b/src/Discord/Types/Channel.hs
@@ -171,6 +171,7 @@ data Message = Message
   , messageNonce        :: Maybe Snowflake -- ^ Used for validating if a message
                                            --   was sent
   , messagePinned       :: Bool            -- ^ Whether this message is pinned
+  , messageGuild        :: Maybe Snowflake -- ^ The guild the message went to
   } deriving (Show, Eq)
 
 instance FromJSON Message where
@@ -189,6 +190,7 @@ instance FromJSON Message where
             <*> o .:  "embeds"
             <*> o .:? "nonce"
             <*> o .:? "pinned" .!= False
+            <*> o .:? "guild_id" .!= Nothing
 
 -- | Represents an attached to a message file.
 data Attachment = Attachment


### PR DESCRIPTION
A bot/client can be in multiple guilds simultaneously. As a result,
it is useful to be able to distinguish from which guild a message
was originated, without having to either query Discord on each
message (to ask which guild owns a channel ID) or store that
information ourselves in our apps.

Signed-off-by: Rick Elrod <rick@elrod.me>