### PR TITLE
Add Activity type for updating game status

### DIFF
--- a/src/Discord/Types/Gateway.hs
+++ b/src/Discord/Types/Gateway.hs
@@ -63,14 +63,14 @@ data UpdateStatusOpts = UpdateStatusOpts
 
 data Activity = Activity
               { activityName :: T.Text
-              , activityType :: ActivityTypes
+              , activityType :: ActivityType
               , activityUrl :: Maybe T.Text
               }
   deriving (Show)
 
-data ActivityTypes = ActivityTypeGame
-                   | ActivityTypeStreaming
-                   | ActivityTypeListening
+data ActivityType = ActivityTypeGame
+                  | ActivityTypeStreaming
+                  | ActivityTypeListening
   deriving (Enum, Show)
 
 data UpdateStatusTypes = UpdateStatusOnline

--- a/src/Discord/Types/Gateway.hs
+++ b/src/Discord/Types/Gateway.hs
@@ -40,9 +40,9 @@ data GatewaySendable
   deriving (Show)
 
 data RequestGuildMembersOpts = RequestGuildMembersOpts
-                             { requestGuildMemersGuildId :: Snowflake
-                             , requestGuildMemersSearchQuery :: T.Text
-                             , requestGuildMemersLimit :: Integer }
+                             { requestGuildMembersGuildId :: Snowflake
+                             , requestGuildMembersSearchQuery :: T.Text
+                             , requestGuildMembersLimit :: Integer }
   deriving (Show)
 
 data UpdateStatusVoiceOpts = UpdateStatusVoiceOpts
@@ -55,11 +55,23 @@ data UpdateStatusVoiceOpts = UpdateStatusVoiceOpts
 
 data UpdateStatusOpts = UpdateStatusOpts
                       { updateStatusSince :: Maybe UTCTime
-                      -- todo , updateStatusGame :: Activity
+                      , updateStatusGame :: Maybe Activity
                       , updateStatusNewStatus :: UpdateStatusTypes
                       , updateStatusAFK :: Bool
                       }
   deriving (Show)
+
+data Activity = Activity
+              { activityName :: T.Text
+              , activityType :: ActivityTypes
+              , activityUrl :: Maybe T.Text
+              }
+  deriving (Show)
+
+data ActivityTypes = ActivityTypeGame
+                   | ActivityTypeStreaming
+                   | ActivityTypeListening
+  deriving (Enum, Show)
 
 data UpdateStatusTypes = UpdateStatusOnline
                        | UpdateStatusDoNotDisturb
@@ -124,17 +136,19 @@ instance ToJSON GatewaySendable where
       , "shard" .= shard
       ]
     ]
-  toJSON (UpdateStatus (UpdateStatusOpts since status afk)) = object [
+  toJSON (UpdateStatus (UpdateStatusOpts since game status afk)) = object [
       "op" .= (3 :: Int)
     , "d"  .= object [
         "since" .= case since of Nothing -> Nothing
                                  Just s -> Just ((10^6) * (utcTimeToPOSIXSeconds s))
       , "afk" .= afk
       , "status" .= statusString status
-      , "game" .= (Nothing :: Maybe ())
-      -- todo , "game"       .= object [
-      --        "name" .= game
-      --      ]
+      , "game" .= case game of Nothing -> Nothing
+                               Just a -> Just $ object [
+                                           "name" .= activityName a
+                                         , "type" .= (fromEnum $ activityType a :: Int)
+                                         , "url" .= activityUrl a
+                                         ]
       ]
     ]
   toJSON (UpdateStatusVoice (UpdateStatusVoiceOpts guild channel mute deaf)) =


### PR DESCRIPTION
This is my first Haskell PR, so I would appreciate any feedback on how to improve it.

I've created a simple `Activity` type based on the [Discord docs](https://discordapp.com/developers/docs/topics/gateway#activity-object), and tested that updating the activity works in a `discord-haskell` bot that I made using this code.