### PR TITLE
Handle CloseRequest 1001 event from Discord gateway

### DIFF
--- a/src/Discord/Gateway/EventLoop.hs
+++ b/src/Discord/Gateway/EventLoop.hs
@@ -174,8 +174,9 @@ eventStream (ConnData conn seshID auth eventChan) seqKey interval send log = loo
     eitherPayload <- getPayloadTimeout conn interval log
     case eitherPayload :: Either ConnectionException GatewayReceivable of
       Left (CloseRequest code str) -> case code of
-          -- see discord documentation on gateway close event codes
+          -- see Discord and MDN documentation on gateway close event codes
           1000 -> ConnReconnect auth seshID <$> readIORef seqKey
+          1001 -> ConnReconnect auth seshID <$> readIORef seqKey
           4000 -> ConnReconnect auth seshID <$> readIORef seqKey
           4006 -> pure ConnStart
           4007 -> ConnReconnect auth seshID <$> readIORef seqKey


### PR DESCRIPTION
This should fix the following error which I encountered (#1):

> Event error: GatewayExceptionConnection (CloseRequest 1001 "") "Normal event loop close request"
> discord-haskell-bot-exe: thread blocked indefinitely in an MVar operation

Not sure if this is the right way to fix it or kind of a hack. The [Discord API docs](https://discordapp.com/developers/docs/topics/opcodes-and-status-codes#rpc) don't mention the error code 1001, but there is a list of close event codes on MDN [here](https://developer.mozilla.org/en-US/docs/Web/API/CloseEvent). Seeing the list there makes me wonder, should other codes be handled too, like 1002, 1003, 1007, etc.?

I should also mention that I haven't gotten to test this yet, can run my bot for a week with this PR to verify that my fix prevents it from crashing.

EDIT: My guess would be that it would be best to not handle other 100x error codes unless they come up in the future. 1001 seems like a special case with Discord websockets that happens because of Cloudflare.