### PR TITLE
GuildRoleDelete: returns role_id instead of role

### DIFF
--- a/src/Discord/Types/Events.hs
+++ b/src/Discord/Types/Events.hs
@@ -139,7 +139,7 @@ eventParse t o = case t of
     "GUILD_MEMBER_CHUNK"        -> GuildMemberChunk <$> o .: "guild_id" <*> o .: "members"
     "GUILD_ROLE_CREATE"         -> GuildRoleCreate  <$> o .: "guild_id" <*> o .: "role"
     "GUILD_ROLE_UPDATE"         -> GuildRoleUpdate  <$> o .: "guild_id" <*> o .: "role"
-    "GUILD_ROLE_DELETE"         -> GuildRoleDelete  <$> o .: "guild_id" <*> o .: "role"
+    "GUILD_ROLE_DELETE"         -> GuildRoleDelete  <$> o .: "guild_id" <*> o .: "role_id"
     "MESSAGE_CREATE"            -> MessageCreate     <$> reparse o
     "MESSAGE_UPDATE"            -> MessageUpdate     <$> o .: "channel_id" <*> o .: "id"
     "MESSAGE_DELETE"            -> MessageDelete     <$> o .: "channel_id" <*> o .: "id"


### PR DESCRIPTION
While running my bot, I noticed another crash that happened whenever a Role was deleted.

```
Event error: GatewayExceptionEventParseError "Error in $: key \"role\" not present"
"Normal event loop"
```

From reading through the Discord documentation on Roles, it seems that GuildRoleDelete returns a role_id instead of a full role object.

https://discordapp.com/developers/docs/topics/gateway#guild-role-delete

I think I've made the right changes here, hope this helps!