### PR TITLE
Add ActivityTypeWatching to ActivityType enum

### DIFF
--- a/src/Discord/Types/Gateway.hs
+++ b/src/Discord/Types/Gateway.hs
@@ -71,6 +71,7 @@ data Activity = Activity
 data ActivityType = ActivityTypeGame
                   | ActivityTypeStreaming
                   | ActivityTypeListening
+                  | ActivityTypeWatching
   deriving (Enum, Show)
 
 data UpdateStatusType = UpdateStatusOnline


### PR DESCRIPTION
Realized that in my previous PR I neglected to handle the "Watching" activity type. It's not mentioned [here](https://discordapp.com/developers/docs/topics/gateway#activity-object-activity-types) but is [here](https://discordapp.com/developers/docs/game-sdk/activities#data-models-activitytype-enum). I've seen other Discord bots use this status and have tested this PR in my own Haskell bot.