### PR TITLE
Simply ping-pong.hs

### DIFF
--- a/examples/ping-pong.hs
+++ b/examples/ping-pong.hs
@@ -33,9 +33,7 @@ loopingPing dis = do
       _ -> loopingPing dis
 
 fromBot :: Message -> Bool
-fromBot m = case messageAuthor m of
-              Right u -> userIsBot u
-              Left _webhookid -> True
+fromBot m = userIsBot (messageAuthor m)
 
 isPing :: T.Text -> Bool
 isPing = T.isPrefixOf "ping" . T.map toLower


### PR DESCRIPTION
Hi, thanks for the awesome package.

Adding a quickfix to `examples/ping-pong.hs`.

Changelog states (for latest aka v0.8.3): **Simplify Message Author from `Either WebhookId User` to `User`**

So `fromBot` can be simplified.