### PR TITLE
Add new MessageReactionRemoveEmoji event and endpoint

### DIFF
--- a/src/Discord/Internal/Rest/Channel.hs
+++ b/src/Discord/Internal/Rest/Channel.hs
@@ -58,6 +58,8 @@ data ChannelRequest a where
   DeleteOwnReaction       :: (ChannelId, MessageId) -> T.Text -> ChannelRequest ()
   -- | Remove a Reaction someone else added
   DeleteUserReaction      :: (ChannelId, MessageId) -> UserId -> T.Text -> ChannelRequest ()
+  -- | Deletes all reactions of a single emoji on a message
+  DeleteSingleReaction    :: (ChannelId, MessageId) -> T.Text -> ChannelRequest ()
   -- | List of users that reacted with this emoji
   GetReactions            :: (ChannelId, MessageId) -> T.Text -> (Int, ReactionTiming) -> ChannelRequest ()
   -- | Delete all reactions on a message
@@ -186,6 +188,7 @@ channelMajorRoute c = case c of
   (CreateReaction (chan, _) _) ->     "add_react " <> show chan
   (DeleteOwnReaction (chan, _) _) ->      "react " <> show chan
   (DeleteUserReaction (chan, _) _ _) ->   "react " <> show chan
+  (DeleteSingleReaction (chan, _) _) ->   "react " <> show chan
   (GetReactions (chan, _) _ _) ->         "react " <> show chan
   (DeleteAllReactions (chan, _)) ->       "react " <> show chan
   (EditMessage (chan, _) _ _) ->        "get_msg " <> show chan
@@ -268,6 +271,10 @@ channelJsonRequest c = case c of
   (DeleteUserReaction (chan, msgid) uID emoji) ->
       let e = cleanupEmoji emoji
       in Delete (channels // chan /: "messages" // msgid /: "reactions" /: e // uID ) mempty
+
+  (DeleteSingleReaction (chan, msgid) emoji) ->
+    let e = cleanupEmoji emoji
+     in Delete (channels // chan /: "messages" // msgid /: "reactions" /: e) mempty
 
   (GetReactions (chan, msgid) emoji (n, timing)) ->
       let e = cleanupEmoji emoji

--- a/src/Discord/Internal/Rest/Channel.hs
+++ b/src/Discord/Internal/Rest/Channel.hs
@@ -274,7 +274,7 @@ channelJsonRequest c = case c of
 
   (DeleteSingleReaction (chan, msgid) emoji) ->
     let e = cleanupEmoji emoji
-     in Delete (channels // chan /: "messages" // msgid /: "reactions" /: e) mempty
+    in Delete (channels // chan /: "messages" // msgid /: "reactions" /: e) mempty
 
   (GetReactions (chan, msgid) emoji (n, timing)) ->
       let e = cleanupEmoji emoji

--- a/src/Discord/Internal/Types/Events.hs
+++ b/src/Discord/Internal/Types/Events.hs
@@ -47,6 +47,7 @@ data Event =
   | MessageReactionAdd      ReactionInfo
   | MessageReactionRemove   ReactionInfo
   | MessageReactionRemoveAll ChannelId MessageId
+  | MessageReactionRemoveEmoji ReactionInfo
   | PresenceUpdate          PresenceInfo
   | TypingStart             TypingInfo
   | UserUpdate              User
@@ -56,7 +57,8 @@ data Event =
   deriving (Show, Eq)
 
 data ReactionInfo = ReactionInfo
-  { reactionUserId    :: UserId
+  { reactionUserId    :: Maybe UserId
+  , reactionGuildId   :: Maybe GuildId
   , reactionChannelId :: ChannelId
   , reactionMessageId :: MessageId
   , reactionEmoji     :: Emoji
@@ -64,7 +66,8 @@ data ReactionInfo = ReactionInfo
 
 instance FromJSON ReactionInfo where
   parseJSON = withObject "ReactionInfo" $ \o ->
-    ReactionInfo <$> o .: "user_id"
+    ReactionInfo <$> o .:? "user_id"
+                 <*> o .:? "guild_id"
                  <*> o .: "channel_id"
                  <*> o .: "message_id"
                  <*> o .: "emoji"
@@ -147,6 +150,7 @@ eventParse t o = case t of
     "MESSAGE_REACTION_REMOVE"   -> MessageReactionRemove <$> reparse o
     "MESSAGE_REACTION_REMOVE_ALL" -> MessageReactionRemoveAll <$> o .: "channel_id"
                                                               <*> o .: "message_id"
+    "MESSAGE_REACTION_REMOVE_EMOJI" -> MessageReactionRemoveEmoji <$> reparse o
     "PRESENCE_UPDATE"           -> PresenceUpdate            <$> reparse o
     "TYPING_START"              -> TypingStart               <$> reparse o
     "USER_UPDATE"               -> UserUpdate                <$> reparse o

--- a/src/Discord/Internal/Types/Events.hs
+++ b/src/Discord/Internal/Types/Events.hs
@@ -47,7 +47,7 @@ data Event =
   | MessageReactionAdd      ReactionInfo
   | MessageReactionRemove   ReactionInfo
   | MessageReactionRemoveAll ChannelId MessageId
-  | MessageReactionRemoveEmoji ReactionInfo
+  | MessageReactionRemoveEmoji ReactionRemoveInfo
   | PresenceUpdate          PresenceInfo
   | TypingStart             TypingInfo
   | UserUpdate              User
@@ -57,7 +57,7 @@ data Event =
   deriving (Show, Eq)
 
 data ReactionInfo = ReactionInfo
-  { reactionUserId    :: Maybe UserId
+  { reactionUserId    :: UserId
   , reactionGuildId   :: Maybe GuildId
   , reactionChannelId :: ChannelId
   , reactionMessageId :: MessageId
@@ -66,11 +66,25 @@ data ReactionInfo = ReactionInfo
 
 instance FromJSON ReactionInfo where
   parseJSON = withObject "ReactionInfo" $ \o ->
-    ReactionInfo <$> o .:? "user_id"
+    ReactionInfo <$> o .:  "user_id"
                  <*> o .:? "guild_id"
-                 <*> o .: "channel_id"
-                 <*> o .: "message_id"
-                 <*> o .: "emoji"
+                 <*> o .:  "channel_id"
+                 <*> o .:  "message_id"
+                 <*> o .:  "emoji"
+
+data ReactionRemoveInfo  = ReactionRemoveInfo
+  { reactionRemoveChannelId :: ChannelId
+  , reactionRemoveGuildId   :: GuildId
+  , reactionRemoveMessageId :: MessageId
+  , reactionRemoveEmoji     :: Emoji
+  } deriving (Show, Eq, Ord)
+
+instance FromJSON ReactionRemoveInfo where
+  parseJSON = withObject "ReactionRemoveInfo" $ \o ->
+    ReactionRemoveInfo <$> o .:  "guild_id"
+                       <*> o .:  "channel_id"
+                       <*> o .:  "message_id"
+                       <*> o .:  "emoji"
 
 data PresenceInfo = PresenceInfo
   { presenceUserId  :: UserId


### PR DESCRIPTION
This adds the new MESSAGE_REACTION_REMOVE_EMOJI event and endpoint that corresponds with it as per [This PR](https://github.com/discordapp/discord-api-docs/pull/1309/).

- Changes `reactionUserId` to a `Maybe` inside of `ReactionInfo` due to it not being sent with the new event.
- Adds a new `reactionGuildId` property.