### PR TITLE
Add support for the user that created an emoji

### DIFF
--- a/src/Discord/Internal/Types/Guild.hs
+++ b/src/Discord/Internal/Types/Guild.hs
@@ -128,6 +128,7 @@ data Emoji = Emoji
   { emojiId      :: Maybe EmojiId   -- ^ The emoji id
   , emojiName    :: T.Text            -- ^ The emoji name
   , emojiRoles   :: Maybe [RoleId] -- ^ Roles the emoji is active for
+  , emojiUser    :: Maybe User     -- ^ User that created this emoji
   , emojiManaged :: Maybe Bool        -- ^ Whether this emoji is managed
   } deriving (Show, Eq, Ord)
 
@@ -136,6 +137,7 @@ instance FromJSON Emoji where
     Emoji <$> o .:  "id"
           <*> o .:  "name"
           <*> o .:? "roles"
+          <*> o .:? "user"
           <*> o .:? "managed"
 
 -- | Roles represent a set of permissions attached to a group of users. Roles have unique


### PR DESCRIPTION
Hello! 

Thank you so much again for creating this wonderful library! Recently in my bot I needed to retrieve the information about who uploaded emojis to the server, but the library didn't support that (the `user?` field of the [Emoji Object](https://discord.com/developers/docs/resources/emoji)). So I went ahead and added the support for the field. Hope it's not too much trouble to merge this changes to the upstream. Thank you again!

Regards,
rexim