### PR TITLE
Fix some warnings

### DIFF
--- a/examples/cache.hs
+++ b/examples/cache.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
 
-import Data.Monoid ((<>))
 import qualified Data.Text.IO as TIO
 
 import Discord

--- a/examples/gateway.hs
+++ b/examples/gateway.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
 
-import Data.Monoid ((<>))
 import Control.Monad (void, forever)
 import Control.Concurrent (forkIO, killThread)
 import Control.Concurrent.Chan

--- a/examples/ping-pong.hs
+++ b/examples/ping-pong.hs
@@ -26,7 +26,7 @@ pingpongExample = do
                         , discordOnEvent = eventHandler
                         , discordOnLog = \s -> TIO.putStrLn s >> TIO.putStrLn ""
                         }
-  threadDelay (1 `div` 10 * 10^6)
+  threadDelay (1 `div` 10 * 10^(6 :: Int))
   TIO.putStrLn t
 
 -- If the start handler throws an exception, discord-haskell will gracefully shutdown
@@ -48,7 +48,7 @@ eventHandler :: DiscordHandle -> Event -> IO ()
 eventHandler dis event = case event of
       MessageCreate m -> when (not (fromBot m) && isPing m) $ do
         _ <- restCall dis (R.CreateReaction (messageChannel m, messageId m) "eyes")
-        threadDelay (4 * 10^6)
+        threadDelay (4 * 10^(6 :: Int))
         _ <- restCall dis (R.CreateMessage (messageChannel m) "Pong!")
         pure ()
       _ -> pure ()

--- a/src/Discord.hs
+++ b/src/Discord.hs
@@ -128,7 +128,7 @@ restCall h r = do empty <- isEmptyMVar (discordHandleLibraryError h)
                         Left (RestCallInternalErrorCode c e1 e2) ->
                           pure (Left (RestCallErrorCode c (TE.decodeUtf8 e1) (TE.decodeUtf8 e2)))
                         Left (RestCallInternalHttpException _) ->
-                          threadDelay (10 * 10^6) >> restCall h r
+                          threadDelay (10 * 10^(6 :: Int)) >> restCall h r
                         Left (RestCallInternalNoParse err dat) -> do
                           let formaterr = T.pack ("Parse Exception " <> err <> " for " <> show dat)
                           writeChan (discordHandleLog h) formaterr
@@ -153,7 +153,7 @@ readCache h = do merr <- readMVar (snd (discordHandleCache h))
 -- | Stop all the background threads
 stopDiscord :: DiscordHandle -> IO ()
 stopDiscord h = do _ <- tryPutMVar (discordHandleLibraryError h) "Library has closed"
-                   threadDelay (10^6 `div` 10)
+                   threadDelay (10^(6 :: Int) `div` 10)
                    mapM_ (killThread . toId) (discordHandleThreads h)
   where toId t = case t of
                    DiscordHandleThreadIdRest a -> a

--- a/src/Discord/Internal/Gateway/Cache.hs
+++ b/src/Discord/Internal/Gateway/Cache.hs
@@ -4,7 +4,6 @@
 module Discord.Internal.Gateway.Cache where
 
 import Prelude hiding (log)
-import Data.Monoid ((<>))
 import Control.Monad (forever)
 import Control.Concurrent.MVar
 import Control.Concurrent.Chan

--- a/src/Discord/Internal/Gateway/EventLoop.hs
+++ b/src/Discord/Internal/Gateway/EventLoop.hs
@@ -89,7 +89,7 @@ connectionLoop auth (events, userSend) log = loop ConnStart 0
                       startEventStream (ConnData conn seshID auth events) interval seqID userSend log
                   Right (InvalidSession retry) -> do
                       t <- getRandomR (1,5)
-                      threadDelay (t * 10^6)
+                      threadDelay (t * (10^(6 :: Int)))
                       pure $ if retry
                              then ConnReconnect (Auth tok) seshID seqID
                              else ConnStart
@@ -129,7 +129,7 @@ getPayload conn log = try $ do
 
 heartbeat :: Chan GatewaySendable -> Int -> IORef Integer -> IO ()
 heartbeat send interval seqKey = do
-  threadDelay (1 * 10^6)
+  threadDelay (1 * 10^(6 :: Int))
   forever $ do
     num <- readIORef seqKey
     writeChan send (Heartbeat num)
@@ -207,7 +207,7 @@ data Sendables = Sendables { -- | Things the user wants to send. Doesn't reset o
 sendableLoop :: Connection -> Sendables -> IO ()
 sendableLoop conn sends = forever $ do
   -- send a ~120 events a min by delaying
-  threadDelay (round (10^6 * (62 / 120)))
+  threadDelay $ round ((10^(6 :: Int)) * (62 / 120) :: Double)
   let e :: Either GatewaySendable GatewaySendable -> GatewaySendable
       e = either id id
   payload <- e <$> race (readChan (userSends sends)) (readChan (gatewaySends sends))

--- a/src/Discord/Internal/Gateway/EventLoop.hs
+++ b/src/Discord/Internal/Gateway/EventLoop.hs
@@ -13,7 +13,6 @@ import Control.Concurrent.Async (race)
 import Control.Concurrent.Chan
 import Control.Concurrent (threadDelay, killThread, forkIO)
 import Control.Exception.Safe (try, finally, handle, SomeException)
-import Data.Monoid ((<>))
 import Data.IORef
 import Data.Aeson (eitherDecode, encode)
 import qualified Data.Text as T
@@ -104,7 +103,7 @@ connectionLoop auth (events, userSend) log = loop ConnStart 0
                       pure ConnClosed
           case next :: Either SomeException ConnLoopState of
             Left _ -> do t <- getRandomR (3,20)
-                         threadDelay (t * 10^6)
+                         threadDelay (t * (10^(6 :: Int)))
                          writeChan log ("gateway - trying to reconnect after " <> T.pack (show retries)
                                                <> " failures")
                          loop (ConnReconnect (Auth tok) seshID seqID) (retries + 1)

--- a/src/Discord/Internal/Rest/Channel.hs
+++ b/src/Discord/Internal/Rest/Channel.hs
@@ -19,7 +19,6 @@ module Discord.Internal.Rest.Channel
 
 import Data.Aeson
 import Data.Emoji (unicodeByName)
-import Data.Monoid (mempty, (<>))
 import qualified Data.Text as T
 import qualified Data.ByteString as B
 import qualified Data.ByteString.Lazy as BL

--- a/src/Discord/Internal/Rest/Emoji.hs
+++ b/src/Discord/Internal/Rest/Emoji.hs
@@ -13,7 +13,6 @@ module Discord.Internal.Rest.Emoji
   ) where
 
 import Data.Aeson
-import Data.Monoid (mempty, (<>))
 import Codec.Picture
 import Network.HTTP.Req ((/:))
 import qualified Network.HTTP.Req as R

--- a/src/Discord/Internal/Rest/Guild.hs
+++ b/src/Discord/Internal/Rest/Guild.hs
@@ -21,7 +21,6 @@ module Discord.Internal.Rest.Guild
 
 
 import Data.Aeson
-import Data.Monoid (mempty, (<>))
 import Network.HTTP.Req ((/:))
 import qualified Network.HTTP.Req as R
 import qualified Data.Text as T

--- a/src/Discord/Internal/Rest/HTTP.hs
+++ b/src/Discord/Internal/Rest/HTTP.hs
@@ -11,7 +11,6 @@ module Discord.Internal.Rest.HTTP
   ) where
 
 import Prelude hiding (log)
-import Data.Semigroup ((<>))
 
 import Control.Monad.IO.Class (liftIO)
 import Control.Concurrent (threadDelay)

--- a/src/Discord/Internal/Rest/HTTP.hs
+++ b/src/Discord/Internal/Rest/HTTP.hs
@@ -100,8 +100,8 @@ tryRequest _log action = do
   let body   = R.responseBody resp
       code   = R.responseStatusCode resp
       status = R.responseStatusMessage resp
-      global = (Just "true" ==) $ readMaybeBS =<< R.responseHeader resp "X-RateLimit-Global"
-      remain = fromMaybe 1 $ readMaybeBS =<< R.responseHeader resp "X-RateLimit-Remaining"
+      global = (Just ("true" :: String) ==) $ readMaybeBS =<< R.responseHeader resp "X-RateLimit-Global"
+      remain = fromMaybe 1 $ readMaybeBS =<< R.responseHeader resp "X-RateLimit-Remaining" :: Integer
       reset = withDelta . fromMaybe 10 $ readMaybeBS =<< R.responseHeader resp "X-RateLimit-Reset-After"
 
       withDelta :: Double -> POSIXTime

--- a/src/Discord/Internal/Rest/Invite.hs
+++ b/src/Discord/Internal/Rest/Invite.hs
@@ -10,7 +10,6 @@ module Discord.Internal.Rest.Invite
   ( InviteRequest(..)
   ) where
 
-import Data.Monoid (mempty)
 import Network.HTTP.Req ((/:))
 import qualified Network.HTTP.Req as R
 import qualified Data.Text as T

--- a/src/Discord/Internal/Rest/Prelude.hs
+++ b/src/Discord/Internal/Rest/Prelude.hs
@@ -9,7 +9,6 @@ module Discord.Internal.Rest.Prelude where
 import Prelude hiding (log)
 import Control.Exception.Safe (throwIO)
 import Control.Monad.IO.Class (MonadIO, liftIO)
-import Data.Monoid ((<>))
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as TE
 

--- a/src/Discord/Internal/Rest/User.hs
+++ b/src/Discord/Internal/Rest/User.hs
@@ -14,7 +14,6 @@ module Discord.Internal.Rest.User
 
 import Data.Aeson
 import Codec.Picture
-import Data.Monoid (mempty, (<>))
 import Network.HTTP.Req ((/:))
 import qualified Network.HTTP.Req as R
 import qualified Data.Text as T

--- a/src/Discord/Internal/Rest/Webhook.hs
+++ b/src/Discord/Internal/Rest/Webhook.hs
@@ -14,7 +14,6 @@ module Discord.Internal.Rest.Webhook
   ) where
 
 import Data.Aeson
-import Data.Monoid (mempty, (<>))
 import qualified Data.Text as T
 import qualified Data.ByteString as B
 import qualified Data.ByteString.Lazy as BL

--- a/src/Discord/Internal/Types/Channel.hs
+++ b/src/Discord/Internal/Types/Channel.hs
@@ -7,7 +7,6 @@ module Discord.Internal.Types.Channel where
 import Control.Applicative (empty)
 import Data.Aeson
 import Data.Aeson.Types (Parser)
-import Data.Monoid ((<>))
 import Data.Text (Text)
 import Data.Time.Clock
 import qualified Data.Text as T

--- a/src/Discord/Internal/Types/Gateway.hs
+++ b/src/Discord/Internal/Types/Gateway.hs
@@ -8,7 +8,6 @@ module Discord.Internal.Types.Gateway where
 import System.Info
 
 import qualified Data.Text as T
-import Data.Monoid ((<>))
 import Data.Time (UTCTime)
 import Data.Time.Clock.POSIX (utcTimeToPOSIXSeconds)
 import Data.Aeson
@@ -141,7 +140,7 @@ instance ToJSON GatewaySendable where
       "op" .= (3 :: Int)
     , "d"  .= object [
         "since" .= case since of Nothing -> Nothing
-                                 Just s -> Just ((10^6) * (utcTimeToPOSIXSeconds s))
+                                 Just s -> Just $ 1000 * utcTimeToPOSIXSeconds s -- takes UTCTime and returns unix time (in milliseconds)
       , "afk" .= afk
       , "status" .= statusString status
       , "game" .= case game of Nothing -> Nothing

--- a/src/Discord/Internal/Types/Prelude.hs
+++ b/src/Discord/Internal/Types/Prelude.hs
@@ -11,7 +11,6 @@ import Data.Aeson.Types
 import Data.Time.Clock
 import qualified Data.Text as T
 import Data.Time.Clock.POSIX
-import Data.Monoid ((<>))
 import Control.Monad (mzero)
 
 import Data.Functor.Compose (Compose(Compose, getCompose))


### PR DESCRIPTION
Removes redundant imports issuing `warning: [-Wunused-imports]` on compile time

Adds type signatures to literals issuing `error: [-Wtype-defaults, -Werror=type-defaults]` on compile time when compiled with `stack build --pedantic`