### PR TITLE
Add CreateMessageDetailed and support for Discord native replies

### DIFF
--- a/examples/ping-pong.hs
+++ b/examples/ping-pong.hs
@@ -61,18 +61,23 @@ eventHandler event = case event of
       MessageCreate m -> when (not (fromBot m) && isPing m) $ do
         _ <- restCall (R.CreateReaction (messageChannel m, messageId m) "eyes")
         threadDelay (4 * 10^(6 :: Int))
-        
+
+        -- A very simple message.
         _ <- restCall (R.CreateMessage (messageChannel m) "Pong!")
 
+        -- A more complex message. Text-to-speech, does not mention everyone nor
+        -- the user, and uses Discord native replies.
         let opts = def { R.messageDetailedContent = "Here's a more complex message, @everyone!"
                        , R.messageDetailedTTS = True
-                       , R.messageDetailedAllowedMentions = Just $ def { R.mentionEveryone = False
-                                                                       , R.mentionRepliedUser = False}
-                       , R.messageDetailedReference = Just $ def { referenceMessageId = Just $ messageId m}
+                       , R.messageDetailedAllowedMentions = Just
+                          $ def { R.mentionEveryone = False
+                                , R.mentionRepliedUser = False
+                                }
+                       , R.messageDetailedReference = Just
+                          $ def { referenceMessageId = Just $ messageId m }
                        }
         _ <- restCall (R.CreateMessageDetailed (messageChannel m) opts)
 
-        
         pure ()
       _ -> pure ()
 

--- a/examples/ping-pong.hs
+++ b/examples/ping-pong.hs
@@ -51,7 +51,8 @@ startHandler = do
     Right guild <- restCall $ R.GetGuild (partialGuildId pg)
     Right chans <- restCall $ R.GetGuildChannels (guildId guild)
     case filter isTextChannel chans of
-      (c:_) -> pure ()
+      (c:_) -> do _ <- restCall $ R.CreateMessage (channelId c) "Hello! I will reply to pings with pongs"
+                  pure ()
       _ -> pure ()
 
 -- If an event handler throws an exception, discord-haskell will continue to run

--- a/examples/ping-pong.hs
+++ b/examples/ping-pong.hs
@@ -62,7 +62,9 @@ eventHandler event = case event of
         _ <- restCall (R.CreateReaction (messageChannel m, messageId m) "eyes")
         threadDelay (4 * 10^(6 :: Int))
         
-        let opts = def { R.messageDetailedContent = "Pong! @everyone"
+        _ <- restCall (R.CreateMessage (messageChannel m) "Pong!")
+
+        let opts = def { R.messageDetailedContent = "Here's a more complex message, @everyone!"
                        , R.messageDetailedTTS = True
                        , R.messageDetailedAllowedMentions = Just $ def { R.mentionEveryone = False
                                                                        , R.mentionRepliedUser = False}

--- a/examples/ping-pong.hs
+++ b/examples/ping-pong.hs
@@ -61,7 +61,7 @@ eventHandler event = case event of
       MessageCreate m -> when (not (fromBot m) && isPing m) $ do
         _ <- restCall (R.CreateReaction (messageChannel m, messageId m) "eyes")
         threadDelay (4 * 10^(6 :: Int))
-        _ <- restCall (R.CreateMessage (messageChannel m) "Pong!")
+        _ <- restCall (R.CreateMessageReply (messageChannel m, messageId m) "Pong!")
         pure ()
       _ -> pure ()
 

--- a/src/Discord/Internal/Types/Channel.hs
+++ b/src/Discord/Internal/Types/Channel.hs
@@ -250,8 +250,8 @@ data Message = Message
                                            --   was sent
   , messagePinned       :: Bool            -- ^ Whether this message is pinned
   , messageGuild        :: Maybe GuildId   -- ^ The guild the message went to
-  , messageReference    :: Maybe MessageReference
-  , referencedMessage   :: Maybe Message
+  , messageReference    :: Maybe MessageReference -- ^ Reference IDs of the original message 
+  , referencedMessage   :: Maybe Message   -- ^ The full original message
   } deriving (Show, Eq, Ord)
 
 instance FromJSON Message where
@@ -347,7 +347,7 @@ data MessageReference = MessageReference
   { referenceMessageId       :: Maybe MessageId  -- ^ 	id of the originating message
   , referenceChannelId       :: Maybe ChannelId  -- ^ 	id of the originating message's channel
   , referenceGuildId         :: Maybe GuildId    -- ^ id of the originating message's guild
-  , failIfNotExists :: Bool             -- ^ Whether to not send if reference not exist
+  , failIfNotExists :: Bool                      -- ^ Whether to not send if reference not exist
   } deriving (Show, Eq, Ord)
 
 instance FromJSON MessageReference where

--- a/src/Discord/Internal/Types/Channel.hs
+++ b/src/Discord/Internal/Types/Channel.hs
@@ -7,6 +7,7 @@ module Discord.Internal.Types.Channel where
 import Control.Applicative (empty)
 import Data.Aeson
 import Data.Aeson.Types (Parser)
+import Data.Default (Default, def)
 import Data.Text (Text)
 import Data.Time.Clock
 import qualified Data.Text as T
@@ -344,10 +345,10 @@ instance FromJSON Nonce where
 
 -- | Represents a Message Reference
 data MessageReference = MessageReference
-  { referenceMessageId       :: Maybe MessageId  -- ^ 	id of the originating message
-  , referenceChannelId       :: Maybe ChannelId  -- ^ 	id of the originating message's channel
-  , referenceGuildId         :: Maybe GuildId    -- ^ id of the originating message's guild
-  , failIfNotExists :: Bool                      -- ^ Whether to not send if reference not exist
+  { referenceMessageId      :: Maybe MessageId  -- ^ id of the originating message
+  , referenceChannelId      :: Maybe ChannelId  -- ^ id of the originating message's channel
+  , referenceGuildId        :: Maybe GuildId    -- ^ id of the originating message's guild
+  , failIfNotExists         :: Bool             -- ^ Whether to not send if reference not exist
   } deriving (Show, Eq, Ord)
 
 instance FromJSON MessageReference where
@@ -364,3 +365,10 @@ instance ToJSON MessageReference where
               , ("guild_id",  toJSON <$> pure referenceGuildId)
               , ("fail_if_not_exists",   toJSON <$> pure failIfNotExists)
               ] ]
+
+instance Default MessageReference where
+  def = MessageReference { referenceMessageId = Nothing
+                         , referenceChannelId = Nothing
+                         , referenceGuildId   = Nothing
+                         , failIfNotExists    = False
+                         }

--- a/src/Discord/Internal/Types/Channel.hs
+++ b/src/Discord/Internal/Types/Channel.hs
@@ -251,7 +251,7 @@ data Message = Message
                                            --   was sent
   , messagePinned       :: Bool            -- ^ Whether this message is pinned
   , messageGuild        :: Maybe GuildId   -- ^ The guild the message went to
-  , messageReference    :: Maybe MessageReference -- ^ Reference IDs of the original message 
+  , messageReference    :: Maybe MessageReference -- ^ Reference IDs of the original message
   , referencedMessage   :: Maybe Message   -- ^ The full original message
   } deriving (Show, Eq, Ord)
 
@@ -310,7 +310,7 @@ instance FromJSON Emoji where
           <*> o .:? "user"
           <*> o .:? "managed"
 
-  
+
 -- | Represents an attached to a message file.
 data Attachment = Attachment
   { attachmentId       :: Snowflake     -- ^ Attachment id


### PR DESCRIPTION
Discord introduced their native "reply" feature a while back. It seems like cross-posted messages from news channels also use the same format. I thought I'd take a go at implementing it in `discord-haskell`.
This pull request adds the functionality to create messages with manual controls via `R.CreateMessageDetailed`, and also adds support for native replies on the way. 

## Changes:
- Added `messageReference` and `referencedMessage` fields in the Message type, as per the [docs](https://discord.com/developers/docs/resources/channel#message-object).
  - Former contains a `Maybe MessageReference` (expanded below) of the original message if it exists.
  - Latter contains a `Maybe Message` of the full original message ([only present in Replies](https://i.imgur.com/0zEX6QZ.png); Therefore messageReference does not imply the presence of referencedMessage)
- Added the `MessageReference` type, following the [Discord API object of the same name](https://discord.com/developers/docs/resources/channel#message-object-message-reference-structure).
  - It contains the `MessageId`, `ChannelId`, and optional `GuildId` of the referenced message.
  - Personally I feel no need for this because the same information can be retrieved from within the `Message`, however I supposed it's there for a reason so I included it.
- Added `CreateMessageDetailed`. Granular controls to send a message. Backwards compatible due to separate name.
  - It takes an ADT `MessageDetailedOpts` in its signature, which is an entirely new ADT featuring extremely granular options for the core users.
  - Also added the ADT `AllowedMentions` which is used in the above Opts as a structure to control what the message is allowed to mention (e.g. disabling @ everyone pings)
- Updated the example ping-pong executable to add a more complex example

## Remaining Issues:
- None