### PR TITLE
added animation status to emojis

### DIFF
--- a/src/Discord/Internal/Types/Channel.hs
+++ b/src/Discord/Internal/Types/Channel.hs
@@ -327,11 +327,12 @@ instance FromJSON MessageReaction where
 
 -- | Represents an emoticon (emoji)
 data Emoji = Emoji
-  { emojiId      :: Maybe EmojiId  -- ^ The emoji id
-  , emojiName    :: T.Text         -- ^ The emoji name
-  , emojiRoles   :: Maybe [RoleId] -- ^ Roles the emoji is active for
-  , emojiUser    :: Maybe User     -- ^ User that created this emoji
-  , emojiManaged :: Maybe Bool     -- ^ Whether this emoji is managed
+  { emojiId       :: Maybe EmojiId  -- ^ The emoji id
+  , emojiName     :: T.Text         -- ^ The emoji name
+  , emojiRoles    :: Maybe [RoleId] -- ^ Roles the emoji is active for
+  , emojiUser     :: Maybe User     -- ^ User that created this emoji
+  , emojiManaged  :: Maybe Bool     -- ^ Whether this emoji is managed
+  , emojiAnimated :: Maybe Bool     -- ^ Whether this emoji is animated
   } deriving (Show, Eq, Ord)
 
 instance FromJSON Emoji where
@@ -341,6 +342,7 @@ instance FromJSON Emoji where
           <*> o .:? "roles"
           <*> o .:? "user"
           <*> o .:? "managed"
+          <*> o .:? "animated"
 
 
 -- | Represents an attached to a message file.


### PR DESCRIPTION
Currently, whether an emoji is animated is not picked up by the parser. I have added a tweak that hopefully rectifies this.