### PR TITLE
Wrap Emoji's emojiName field with Maybe

### DIFF
--- a/src/Discord/Internal/Types/Channel.hs
+++ b/src/Discord/Internal/Types/Channel.hs
@@ -261,7 +261,7 @@ instance FromJSON MessageReaction where
 -- | Represents an emoticon (emoji)
 data Emoji = Emoji
   { emojiId       :: Maybe EmojiId  -- ^ The emoji id
-  , emojiName     :: T.Text         -- ^ The emoji name
+  , emojiName     :: Maybe T.Text   -- ^ The emoji name
   , emojiRoles    :: Maybe [RoleId] -- ^ Roles the emoji is active for
   , emojiUser     :: Maybe User     -- ^ User that created this emoji
   , emojiManaged  :: Maybe Bool     -- ^ Whether this emoji is managed


### PR DESCRIPTION
This PR wraps the `emojiName` field with `Maybe`, changing it from `T.Text` to `Maybe T.Text`. It closes #85, 

This reflects how Discord may return null for its emoji name in some occasions. The key will, however, always exist in the payload so the PR keeps the usage of Aeson's `.:` to parse the value, instead of the `.:?` function (the latter is only recommended for use when the key may not exist).