### PR TITLE
Include embed part in `CreateMessageDetailed`

### DIFF
--- a/src/Discord/Internal/Rest/Channel.hs
+++ b/src/Discord/Internal/Rest/Channel.hs
@@ -303,6 +303,8 @@ channelJsonRequest c = case c of
             Just f  -> [partFileRequestBody "file" (T.unpack $ fst f)
               $ RequestBodyBS $ snd f]
 
+          embedPart = maybeEmbed $ messageDetailedEmbed msgOpts
+
           payloadData =  object $ [ "content" .= messageDetailedContent msgOpts
                                  , "tts"     .= messageDetailedTTS msgOpts ] ++
                                  [ name .= value | (name, Just value) <-
@@ -314,7 +316,7 @@ channelJsonRequest c = case c of
                                     ] ]
           payloadPart = partBS "payload_json" $ BL.toStrict $ encode $ toJSON payloadData
 
-          body = R.reqBodyMultipart (payloadPart : filePart)
+          body = R.reqBodyMultipart (payloadPart : filePart ++ embedPart)
       in Post (channels // chan /: "messages") body mempty
 
   (CreateReaction (chan, msgid) emoji) ->


### PR DESCRIPTION
After migrating from:
```haskell
DR.CreateMessageEmbed channelId body $ def { DT.createEmbedImage = Just ... }
```
to
```haskell
DR.CreateMessageDetailed
              channelId
              def
                { DT.messageDetailedContent   = body
                , DT.messageDetailedEmbed     = Just $ def { DT.createEmbedImage = Just ... }
                }
```
I noticed pictures posted by my bot broke (became small black-ish squares).

After some investigation it seems that `CreateMessageDetailed` is not correctly passing the embed part as a part of the multi-part request (only the passed file). This PR fixes this.