### PR TITLE
Disccord.Internal.Types.Color in exposed-modules

### DIFF
--- a/discord-haskell.cabal
+++ b/discord-haskell.cabal
@@ -84,6 +84,7 @@ library
                      , Discord.Internal.Types.ApplicationCommands
                      , Discord.Internal.Types.Interactions
                      , Discord.Internal.Types.Components
+                     , Discord.Internal.Types.Color
   build-depends:
                        base >= 4 && <5
                      , aeson


### PR DESCRIPTION
Without that it prevents compilation
Fixes #100 