### PR TITLE
Discord module uses IO, add separate MTL module

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This is an example bot that replies "pong" to messages that start with "ping". C
 ```haskell
 {-# LANGUAGE OverloadedStrings #-}  -- allows "string literals" to be Text
 import           Control.Monad (when, void)
-import           UnliftIO.Concurrent
+import           Control.Concurrent (threadDelay)
 import           Data.Text (isPrefixOf, toLower, Text)
 import qualified Data.Text.IO as TIO
 
@@ -42,12 +42,12 @@ pingpongExample = do
     -- userFacingError is an unrecoverable error
     -- put normal 'cleanup' code in discordOnEnd (see examples)
 
-eventHandler :: Event -> DiscordHandler ()
-eventHandler event = case event of
+eventHandler :: DiscordHandle -> Event -> IO ()
+eventHandler handle event = case event of
     MessageCreate m -> when (isPing m && not (fromBot m)) $ do
-        void $ restCall (R.CreateReaction (messageChannelId m, messageId m) "eyes")
+        void $ restCall handle (R.CreateReaction (messageChannelId m, messageId m) "eyes")
         threadDelay (2 * 10^6)
-        void $ restCall (R.CreateMessage (messageChannelId m) "Pong!")
+        void $ restCall handle (R.CreateMessage (messageChannelId m) "Pong!")
     _ -> return ()
 
 fromBot :: Message -> Bool

--- a/discord-haskell.cabal
+++ b/discord-haskell.cabal
@@ -54,6 +54,7 @@ library
   default-language:    Haskell2010
   -- extensions:
   exposed-modules:     Discord
+                     , DiscordMonadTransformerLibrary
                      , Discord.Types
                      , Discord.Handle
                      , Discord.Interactions

--- a/examples/cache.hs
+++ b/examples/cache.hs
@@ -1,8 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 
 import qualified Data.Text.IO as TIO
-import UnliftIO (liftIO)
-
 import Discord
 
 -- There's not much information in the Cache for now
@@ -14,10 +12,10 @@ cacheExample = do
   tok <- TIO.readFile "./examples/auth-token.secret"
 
   _ <- runDiscord $ def { discordToken = tok
-                        , discordOnStart = do
-                               cache <- readCache
-                               liftIO $ putStrLn ("Cached info from gateway: " <> show cache)
-                               stopDiscord
+                        , discordOnStart = \handle -> do
+                               cache <- readCache handle
+                               putStrLn ("Cached info from gateway: " <> show cache)
+                               stopDiscord handle
                         }
   pure ()
 

--- a/examples/gateway.hs
+++ b/examples/gateway.hs
@@ -1,13 +1,12 @@
 {-# LANGUAGE OverloadedStrings #-}
 
 import Control.Monad (forever)
-import Control.Concurrent (forkIO, killThread)
 import UnliftIO (liftIO)
-import Control.Concurrent.Chan
+import UnliftIO.Concurrent
 import qualified Data.Text.IO as TIO
 
-import Discord
 import Discord.Types
+import DiscordMonadTransformerLibrary
 
 -- | Prints every event as it happens
 gatewayExample :: IO ()

--- a/examples/interaction-commands.hs
+++ b/examples/interaction-commands.hs
@@ -10,7 +10,7 @@ import Data.Functor ((<&>))
 import Data.List (transpose)
 import qualified Data.Text as T
 import qualified Data.Text.IO as TIO
-import Discord
+import DiscordMonadTransformerLibrary
 import Discord.Interactions
 import qualified Discord.Requests as R
 import Discord.Types

--- a/examples/ping-pong.hs
+++ b/examples/ping-pong.hs
@@ -7,7 +7,7 @@ import qualified Data.Text.IO as TIO
 import UnliftIO (liftIO)
 import UnliftIO.Concurrent
 
-import Discord
+import DiscordMonadTransformerLibrary
 import Discord.Types
 import qualified Discord.Requests as R
 

--- a/examples/state-counter.hs
+++ b/examples/state-counter.hs
@@ -53,9 +53,10 @@ eventHandler state handle event = case event of
     writeChan (discordHandleLog handle) "got a ping!"
 
     s <- takeMVar state
-    putMVar state $ State { pingCount = pingCount s + 1 }
 
     void $ restCall handle (R.CreateMessage (messageChannelId m) (T.pack ("Pong #" <> show (pingCount s))))
+
+    putMVar state $ State { pingCount = pingCount s + 1 }
 
   _ -> pure ()
 

--- a/src/DiscordMonadTransformerLibrary.hs
+++ b/src/DiscordMonadTransformerLibrary.hs
@@ -1,0 +1,86 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module DiscordMonadTransformerLibrary
+  ( runDiscord
+  , restCall
+  , sendCommand
+  , readCache
+  , stopDiscord
+
+  , DiscordHandler
+
+  , DiscordHandle
+  , Cache(..)
+  , RestCallErrorCode(..)
+  , RunDiscordOpts(..)
+  , FromJSON
+  , def
+  ) where
+
+import Prelude hiding (log)
+import Control.Monad.Reader (ReaderT, runReaderT, ask, liftIO)
+import Data.Aeson (FromJSON)
+import Data.Default (Default, def)
+import qualified Data.Text as T
+
+import Discord.Handle
+import Discord.Internal.Rest
+import Discord.Internal.Gateway
+
+import           Discord (RestCallErrorCode(..))
+import qualified Discord as DIO
+
+type DiscordHandler = ReaderT DiscordHandle IO
+
+data RunDiscordOpts = RunDiscordOpts
+  { discordToken :: T.Text
+  , discordOnStart :: DiscordHandler ()
+  , discordOnEnd :: IO ()
+  , discordOnEvent :: Event -> DiscordHandler ()
+  , discordOnLog :: T.Text -> IO ()
+  , discordForkThreadForEvents :: Bool
+  , discordGatewayIntent :: GatewayIntent
+  }
+
+instance Default RunDiscordOpts where
+  def = RunDiscordOpts { discordToken = ""
+                       , discordOnStart = pure ()
+                       , discordOnEnd = pure ()
+                       , discordOnEvent = \_ -> pure ()
+                       , discordOnLog = \_ -> pure ()
+                       , discordForkThreadForEvents = True
+                       , discordGatewayIntent = def
+                       }
+
+runDiscord :: RunDiscordOpts -> IO T.Text
+runDiscord RunDiscordOpts{..} = DIO.runDiscord $ DIO.RunDiscordOpts
+  { DIO.discordToken = discordToken
+  , discordOnStart = \h -> runReaderT discordOnStart h
+  , discordOnEnd = discordOnEnd
+  , discordOnEvent = \h e -> runReaderT (discordOnEvent e) h
+  , discordOnLog = discordOnLog
+  , discordForkThreadForEvents = discordForkThreadForEvents
+  , discordGatewayIntent = discordGatewayIntent
+  }
+
+-- | Execute one http request and get a response
+restCall :: (FromJSON a, Request (r a)) => r a -> DiscordHandler (Either RestCallErrorCode a)
+restCall r = do h <- ask
+                liftIO $ DIO.restCall h r
+
+-- | Send a user GatewaySendable
+sendCommand :: GatewaySendable -> DiscordHandler ()
+sendCommand e = do h <- ask
+                   liftIO $ DIO.sendCommand h e
+
+-- | Access the current state of the gateway cache
+readCache :: DiscordHandler Cache
+readCache = do h <- ask
+               liftIO $ DIO.readCache h
+
+stopDiscord :: DiscordHandler ()
+stopDiscord = do h <- ask
+                 liftIO $ DIO.stopDiscord h


### PR DESCRIPTION
All the existing code can change `import Discord` into `import DiscordMonadTransformerLibrary` and will compile and run correctly.

New code (and examples) can use the new `import Discord` to get `IO ()` based functions, instead of `DiscordHandler = ReaderT DiscordHandle IO`.

The long and explicit name is make `import Discord` the clear default UI to the library, so it's easy as possible for those newer to the haskell language.

An alternate design I considered was leaving `import Discord` as is, and adding a `Discord.IO` module for the `IO` utilities. This is nice because old code works with no change, but could be confusing.