### PR TITLE
Unwrap CreateEmbed Parameter

### DIFF
--- a/src/Discord/Internal/Rest/Channel.hs
+++ b/src/Discord/Internal/Rest/Channel.hs
@@ -518,7 +518,7 @@ channelJsonRequest c = case c of
                     (RequestBodyBS $ snd f)
                 ]
           )
-            ++ join (maybe [] (maybeEmbed . Just <$>) (messageDetailedEmbeds msgOpts))
+            ++ join (maybe [] (embedPart <$>) (messageDetailedEmbeds msgOpts))
 
         payloadData =  objectFromMaybes $
                         [ "content" .== messageDetailedContent msgOpts
@@ -573,7 +573,7 @@ channelJsonRequest c = case c of
                     (RequestBodyBS $ snd f)
                 ]
           )
-            ++ join (maybe [] (maybeEmbed . Just <$>) (messageDetailedEmbeds msgOpts))
+            ++ join (maybe [] (embedPart <$>) (messageDetailedEmbeds msgOpts))
 
         payloadData =  objectFromMaybes $
                         [ "content" .== messageDetailedContent msgOpts

--- a/src/Discord/Internal/Rest/Interactions.hs
+++ b/src/Discord/Internal/Rest/Interactions.hs
@@ -87,4 +87,4 @@ interactionResponseJsonRequest a = case a of
     convert' :: InteractionResponseMessage -> [PartM IO]
     convert' InteractionResponseMessage {..} = case interactionResponseMessageEmbeds of
       Nothing -> []
-      Just f -> (maybeEmbed . Just) =<< f
+      Just f -> embedPart =<< f

--- a/src/Discord/Internal/Types/Embed.hs
+++ b/src/Discord/Internal/Types/Embed.hs
@@ -273,12 +273,12 @@ instance FromJSON EmbedField where
                <*> o .:? "inline"
 
 
-maybeEmbed :: Maybe CreateEmbed -> [PartM IO]
-maybeEmbed =
+embedPart :: CreateEmbed -> [PartM IO]
+embedPart =
       let mkPart (name,content) = partFileRequestBody name (T.unpack name) (RequestBodyBS content)
           uploads CreateEmbed{..} = [(T.filter (/=' ') $ createEmbedTitle<>n,c) | (n, Just (CreateEmbedImageUpload c)) <-
                                           [ ("author.png", createEmbedAuthorIcon)
                                           , ("thumbnail.png", createEmbedThumbnail)
                                           , ("image.png", createEmbedImage)
                                           , ("footer.png", createEmbedFooterIcon) ]]
-      in maybe [] (map mkPart . uploads)
+      in map mkPart . uploads


### PR DESCRIPTION
This function is only ever called with the parameter wrapped in `Just` at the call site, so the `Maybe` can be removed.