### PR TITLE
Fix ToJSON Instance of AutoModerationRule

### DIFF
--- a/src/Discord/Internal/Types/AutoModeration.hs
+++ b/src/Discord/Internal/Types/AutoModeration.hs
@@ -40,7 +40,7 @@ instance FromJSON AutoModerationRule where
 
 instance ToJSON AutoModerationRule where
   toJSON AutoModerationRule{..} = object
-    [ ("id", toJSON autoModerationRuleGuildId)
+    [ ("id", toJSON autoModerationRuleId)
     , ("guild_id", toJSON autoModerationRuleGuildId)
     , ("name", toJSON autoModerationRuleName)
     , ("creator_id", toJSON autoModerationRuleCreatorId)


### PR DESCRIPTION
This looks like a copy-paste error. This makes it consistent with [the docs](https://docs.discord.com/developers/resources/auto-moderation#auto-moderation-rule-object) and the existing `FromJSON` instance.