### PR TITLE
Fix `EditFollowupInteractionMessage` Constructor

### DIFF
--- a/src/Discord/Internal/Rest/Interactions.hs
+++ b/src/Discord/Internal/Rest/Interactions.hs
@@ -37,7 +37,7 @@ data InteractionResponseRequest a where
   -- | Returns a followup message for an Interaction.
   GetFollowupInteractionMessage :: ApplicationId -> InteractionToken -> MessageId -> InteractionResponseRequest Message
   -- | Edits a followup message for an Interaction.
-  EditFollowupInteractionMessage :: ApplicationId -> InteractionToken -> MessageId -> InteractionResponse -> InteractionResponseRequest Message
+  EditFollowupInteractionMessage :: ApplicationId -> InteractionToken -> MessageId -> InteractionResponseMessage -> InteractionResponseRequest Message
   -- | Deletes a followup message for an Interaction.
   DeleteFollowupInteractionMessage :: ApplicationId -> InteractionToken -> MessageId -> InteractionResponseRequest ()
 
@@ -74,7 +74,7 @@ interactionResponseJsonRequest a = case a of
   (GetFollowupInteractionMessage aid it mid) ->
     Get (interaction aid it /~ mid) mempty
   (EditFollowupInteractionMessage aid it mid i) ->
-    Patch (interaction aid it /~ mid) (convert i) mempty
+    Patch (interaction aid it /~ mid) (convertIRM i) mempty
   (DeleteFollowupInteractionMessage aid it mid) ->
     Delete (interaction aid it /~ mid) mempty
   where


### PR DESCRIPTION
Make `EditFollowupInteractionMessage` take an `InteractionResponseMessage` instead of an `InteractionResponse`.

This is in accordance with the documentation for [edit followup message](https://docs.discord.com/developers/interactions/receiving-and-responding#edit-followup-message) and [edit webhook message](https://docs.discord.com/developers/resources/webhook#edit-webhook-message), which take a "message-like" value and not a response value.

Tested briefly to confirm that editing followup messages has the intended effect.

Discussion at https://discord.com/channels/918577626954739722/918577626954739726/1499329771975479328