### PR TITLE
Enable Using Attachments in Interaction Responses

### DIFF
--- a/src/Discord/Internal/Rest/Channel.hs
+++ b/src/Discord/Internal/Rest/Channel.hs
@@ -518,7 +518,7 @@ channelJsonRequest c = case c of
                     (RequestBodyBS $ snd f)
                 ]
           )
-            ++ join (maybe [] (maybeEmbed . Just <$>) (messageDetailedEmbeds msgOpts))
+            ++ join (maybe [] (embedPart <$>) (messageDetailedEmbeds msgOpts))
 
         payloadData =  objectFromMaybes $
                         [ "content" .== messageDetailedContent msgOpts
@@ -573,7 +573,7 @@ channelJsonRequest c = case c of
                     (RequestBodyBS $ snd f)
                 ]
           )
-            ++ join (maybe [] (maybeEmbed . Just <$>) (messageDetailedEmbeds msgOpts))
+            ++ join (maybe [] (embedPart <$>) (messageDetailedEmbeds msgOpts))
 
         payloadData =  objectFromMaybes $
                         [ "content" .== messageDetailedContent msgOpts

--- a/src/Discord/Internal/Rest/Interactions.hs
+++ b/src/Discord/Internal/Rest/Interactions.hs
@@ -79,11 +79,13 @@ interactionResponseJsonRequest a = case a of
     Delete (interaction aid it /~ mid) mempty
   where
     bodyIR :: InteractionResponse -> RestIO R.ReqBodyMultipart
-    bodyIR ir@(InteractionResponseChannelMessage irm) = R.reqBodyMultipart (partBS "payload_json" (BL.toStrict $ encode ir) : files irm)
-    bodyIR ir@(InteractionResponseUpdateMessage irm) = R.reqBodyMultipart (partBS "payload_json" (BL.toStrict $ encode ir) : files irm)
-    bodyIR ir = R.reqBodyMultipart [partBS "payload_json" $ BL.toStrict $ encode ir]
+    bodyIR ir@(InteractionResponseChannelMessage irm) = R.reqBodyMultipart $ payload ir : files irm
+    bodyIR ir@(InteractionResponseUpdateMessage irm) = R.reqBodyMultipart $ payload ir : files irm
+    bodyIR ir = R.reqBodyMultipart [payload ir]
     bodyIRM :: InteractionResponseMessage -> RestIO R.ReqBodyMultipart
-    bodyIRM irm = R.reqBodyMultipart (partBS "payload_json" (BL.toStrict $ encode irm) : files irm)
+    bodyIRM irm = R.reqBodyMultipart $ payload irm : files irm
+    payload :: ToJSON a => a -> PartM IO
+    payload = partBS "payload_json" . BL.toStrict . encode
     files :: InteractionResponseMessage -> [PartM IO]
     files InteractionResponseMessage {..} = case interactionResponseMessageEmbeds of
       Nothing -> []

--- a/src/Discord/Internal/Rest/Interactions.hs
+++ b/src/Discord/Internal/Rest/Interactions.hs
@@ -5,6 +5,7 @@
 
 module Discord.Internal.Rest.Interactions (InteractionResponseRequest(..)) where
 
+import Data.Maybe
 import Data.Aeson (encode)
 import qualified Data.ByteString.Lazy as BL
 import Discord.Internal.Rest.Prelude
@@ -87,6 +88,5 @@ interactionResponseJsonRequest a = case a of
     payload :: ToJSON a => a -> PartM IO
     payload = partBS "payload_json" . BL.toStrict . encode
     files :: InteractionResponseMessage -> [PartM IO]
-    files InteractionResponseMessage {..} = case interactionResponseMessageEmbeds of
-      Nothing -> []
-      Just f -> embedPart =<< f
+    files InteractionResponseMessage {..} = filesEmbeds where
+      filesEmbeds = fromMaybe [] interactionResponseMessageEmbeds >>= embedPart

--- a/src/Discord/Internal/Rest/Interactions.hs
+++ b/src/Discord/Internal/Rest/Interactions.hs
@@ -87,4 +87,4 @@ interactionResponseJsonRequest a = case a of
     convert' :: InteractionResponseMessage -> [PartM IO]
     convert' InteractionResponseMessage {..} = case interactionResponseMessageEmbeds of
       Nothing -> []
-      Just f -> (maybeEmbed . Just) =<< f
+      Just f -> embedPart =<< f

--- a/src/Discord/Internal/Rest/Interactions.hs
+++ b/src/Discord/Internal/Rest/Interactions.hs
@@ -62,29 +62,29 @@ interaction aid it = baseUrl /: "webhooks" /~ aid /~ it /: "messages"
 interactionResponseJsonRequest :: InteractionResponseRequest a -> JsonRequest
 interactionResponseJsonRequest a = case a of
   (CreateInteractionResponse iid it i) ->
-    Post (baseUrl /: "interactions" /~ iid /~ it /: "callback") (convert i) mempty
+    Post (baseUrl /: "interactions" /~ iid /~ it /: "callback") (bodyIR i) mempty
   (GetOriginalInteractionResponse aid it) ->
     Get (interaction aid it /: "@original") mempty
   (EditOriginalInteractionResponse aid it i) ->
-    Patch (interaction aid it /: "@original") (convertIRM i) mempty
+    Patch (interaction aid it /: "@original") (bodyIRM i) mempty
   (DeleteOriginalInteractionResponse aid it) ->
     Delete (interaction aid it /: "@original") mempty
   (CreateFollowupInteractionMessage aid it i) ->
-    Post (baseUrl /: "webhooks" /~ aid /~ it) (convertIRM i) mempty
+    Post (baseUrl /: "webhooks" /~ aid /~ it) (bodyIRM i) mempty
   (GetFollowupInteractionMessage aid it mid) ->
     Get (interaction aid it /~ mid) mempty
   (EditFollowupInteractionMessage aid it mid i) ->
-    Patch (interaction aid it /~ mid) (convertIRM i) mempty
+    Patch (interaction aid it /~ mid) (bodyIRM i) mempty
   (DeleteFollowupInteractionMessage aid it mid) ->
     Delete (interaction aid it /~ mid) mempty
   where
-    convert :: InteractionResponse -> RestIO R.ReqBodyMultipart
-    convert ir@(InteractionResponseChannelMessage irm) = R.reqBodyMultipart (partBS "payload_json" (BL.toStrict $ encode ir) : convert' irm)
-    convert ir@(InteractionResponseUpdateMessage irm) = R.reqBodyMultipart (partBS "payload_json" (BL.toStrict $ encode ir) : convert' irm)
-    convert ir = R.reqBodyMultipart [partBS "payload_json" $ BL.toStrict $ encode ir]
-    convertIRM :: InteractionResponseMessage -> RestIO R.ReqBodyMultipart
-    convertIRM irm = R.reqBodyMultipart (partBS "payload_json" (BL.toStrict $ encode irm) : convert' irm)
-    convert' :: InteractionResponseMessage -> [PartM IO]
-    convert' InteractionResponseMessage {..} = case interactionResponseMessageEmbeds of
+    bodyIR :: InteractionResponse -> RestIO R.ReqBodyMultipart
+    bodyIR ir@(InteractionResponseChannelMessage irm) = R.reqBodyMultipart (partBS "payload_json" (BL.toStrict $ encode ir) : files irm)
+    bodyIR ir@(InteractionResponseUpdateMessage irm) = R.reqBodyMultipart (partBS "payload_json" (BL.toStrict $ encode ir) : files irm)
+    bodyIR ir = R.reqBodyMultipart [partBS "payload_json" $ BL.toStrict $ encode ir]
+    bodyIRM :: InteractionResponseMessage -> RestIO R.ReqBodyMultipart
+    bodyIRM irm = R.reqBodyMultipart (partBS "payload_json" (BL.toStrict $ encode irm) : files irm)
+    files :: InteractionResponseMessage -> [PartM IO]
+    files InteractionResponseMessage {..} = case interactionResponseMessageEmbeds of
       Nothing -> []
       Just f -> embedPart =<< f

--- a/src/Discord/Internal/Rest/Interactions.hs
+++ b/src/Discord/Internal/Rest/Interactions.hs
@@ -37,7 +37,7 @@ data InteractionResponseRequest a where
   -- | Returns a followup message for an Interaction.
   GetFollowupInteractionMessage :: ApplicationId -> InteractionToken -> MessageId -> InteractionResponseRequest Message
   -- | Edits a followup message for an Interaction.
-  EditFollowupInteractionMessage :: ApplicationId -> InteractionToken -> MessageId -> InteractionResponse -> InteractionResponseRequest Message
+  EditFollowupInteractionMessage :: ApplicationId -> InteractionToken -> MessageId -> InteractionResponseMessage -> InteractionResponseRequest Message
   -- | Deletes a followup message for an Interaction.
   DeleteFollowupInteractionMessage :: ApplicationId -> InteractionToken -> MessageId -> InteractionResponseRequest ()
 
@@ -74,7 +74,7 @@ interactionResponseJsonRequest a = case a of
   (GetFollowupInteractionMessage aid it mid) ->
     Get (interaction aid it /~ mid) mempty
   (EditFollowupInteractionMessage aid it mid i) ->
-    Patch (interaction aid it /~ mid) (convert i) mempty
+    Patch (interaction aid it /~ mid) (convertIRM i) mempty
   (DeleteFollowupInteractionMessage aid it mid) ->
     Delete (interaction aid it /~ mid) mempty
   where

--- a/src/Discord/Internal/Rest/Interactions.hs
+++ b/src/Discord/Internal/Rest/Interactions.hs
@@ -5,6 +5,7 @@
 
 module Discord.Internal.Rest.Interactions (InteractionResponseRequest(..)) where
 
+import Data.Functor
 import Data.Maybe
 import Data.Aeson (encode)
 import qualified Data.ByteString.Lazy as BL
@@ -88,5 +89,6 @@ interactionResponseJsonRequest a = case a of
     payload :: ToJSON a => a -> PartM IO
     payload = partBS "payload_json" . BL.toStrict . encode
     files :: InteractionResponseMessage -> [PartM IO]
-    files InteractionResponseMessage {..} = filesEmbeds where
+    files InteractionResponseMessage {..} = filesEmbeds ++ filesAttachments where
       filesEmbeds = fromMaybe [] interactionResponseMessageEmbeds >>= embedPart
+      filesAttachments = fromMaybe [] interactionResponseMessageAttachments <&> attachmentPart

--- a/src/Discord/Internal/Types/Channel.hs
+++ b/src/Discord/Internal/Types/Channel.hs
@@ -15,6 +15,8 @@ module Discord.Internal.Types.Channel (
   , Message (..)
   , AllowedMentions (..)
   , MessageReaction (..)
+  , CreateAttachment (..)
+  , attachmentPart
   , Attachment (..)
   , Nonce (..)
   , MessageReference (..)
@@ -32,11 +34,15 @@ import Control.Applicative (empty)
 import Data.Aeson
 import Data.Aeson.Types (Parser)
 import Data.Default (Default, def)
+import Data.ByteString (ByteString)
 import Data.Text (Text)
 import Data.Time.Clock
 import qualified Data.Text as T
 import Data.Bits
 import Data.Data (Data)
+import Text.Printf
+import Network.HTTP.Client
+import Network.HTTP.Client.MultipartFormData
 
 import Discord.Internal.Types.Prelude
 import Discord.Internal.Types.User (User(..), GuildMember)
@@ -668,6 +674,24 @@ instance ToJSON MessageReaction where
       , "me" .== messageReactionMeIncluded
       , "emoji" .== messageReactionEmoji
       ]
+
+data CreateAttachment = CreateAttachment
+  { createAttachmentId :: Int
+  , createAttachmentFilename :: Text
+  , createAttachmentData :: ByteString
+  } deriving (Show, Read, Eq, Ord)
+
+instance ToJSON CreateAttachment where
+  toJSON CreateAttachment {..} = objectFromMaybes
+    [ "id" .== createAttachmentId
+    , "filename" .== createAttachmentFilename
+    ]
+
+attachmentPart :: CreateAttachment -> PartM IO
+attachmentPart CreateAttachment {..} = partFileRequestBody name path body where
+  name = T.pack $ printf "files[%d]" createAttachmentId
+  path = T.unpack createAttachmentFilename
+  body = RequestBodyBS createAttachmentData
 
 -- | Represents an attached to a message file.
 data Attachment = Attachment

--- a/src/Discord/Internal/Types/Embed.hs
+++ b/src/Discord/Internal/Types/Embed.hs
@@ -273,12 +273,12 @@ instance FromJSON EmbedField where
                <*> o .:? "inline"
 
 
-maybeEmbed :: Maybe CreateEmbed -> [PartM IO]
-maybeEmbed =
+embedPart :: CreateEmbed -> [PartM IO]
+embedPart =
       let mkPart (name,content) = partFileRequestBody name (T.unpack name) (RequestBodyBS content)
           uploads CreateEmbed{..} = [(T.filter (/=' ') $ createEmbedTitle<>n,c) | (n, Just (CreateEmbedImageUpload c)) <-
                                           [ ("author.png", createEmbedAuthorIcon)
                                           , ("thumbnail.png", createEmbedThumbnail)
                                           , ("image.png", createEmbedImage)
                                           , ("footer.png", createEmbedFooterIcon) ]]
-      in maybe [] (map mkPart . uploads)
+      in map mkPart . uploads

--- a/src/Discord/Internal/Types/Interactions.hs
+++ b/src/Discord/Internal/Types/Interactions.hs
@@ -41,7 +41,7 @@ import Data.Bits (Bits (shift, (.|.)))
 import Data.Foldable (Foldable (toList))
 import qualified Data.Text as T
 import Discord.Internal.Types.ApplicationCommands (Choice, Number)
-import Discord.Internal.Types.Channel (AllowedMentions, Attachment, Message)
+import Discord.Internal.Types.Channel (AllowedMentions, CreateAttachment, Message)
 import Discord.Internal.Types.Components (ActionRow, TextInput)
 import Discord.Internal.Types.Embed (CreateEmbed, createEmbed)
 import Discord.Internal.Types.Prelude (ApplicationCommandId, ApplicationId, ChannelId, GuildId, InteractionId, InteractionToken, MessageId, RoleId, Snowflake, UserId, objectFromMaybes, (.=?))
@@ -637,7 +637,7 @@ data InteractionResponseMessage = InteractionResponseMessage
     interactionResponseMessageAllowedMentions :: Maybe AllowedMentions,
     interactionResponseMessageFlags :: Maybe InteractionResponseMessageFlags,
     interactionResponseMessageComponents :: Maybe [ActionRow],
-    interactionResponseMessageAttachments :: Maybe [Attachment]
+    interactionResponseMessageAttachments :: Maybe [CreateAttachment]
   }
   deriving (Show, Read, Eq, Ord)
 


### PR DESCRIPTION
Preliminary [discussion on this topic](https://discord.com/channels/918577626954739722/918577626954739726/1198507734136528897) happened in early 2024.

This PR adds the ability to create attachments when sending interaction responses.
- This is based on #237 and #239. I will rebase this PR to apply cleanly once those are merged.
- The first three commits (e6238831af2d2f8f6d506bf59c51da8e8bf39bae 6623aeb510fa2b7a8a5d4d6a5c01184736a3526b dd88adf8124d578ce6923b277f998578a0727271) are pure refactorings without any change in functionality. I could extract this into a separate PR if wanted.
- Adds `CreateAttachment`. `CreateAttachment` relates to `Attachment` like `CreateEmbed` relates to `Embed`.
- The field `createAttachmentId` is of type `Int` instead of `AttachmentId` since these seem to be indices rather than proper snowflake values. The snowflake values will only be created when the attachment is actually uploaded.
- In `InteractionResponseMessage`, in the type of `interactionResponseMessageAttachments`, changes `Attachment` to `CreateAttachment`.

I feel like the previous `Attachment` value in `InteractionResponseMessage` could not be used in a meaningful way, since it requires an attachment to already exist, and as far as I can tell, there was no way to create one until now. So this change should not restrict any uses that were previously possible, but I am not 100% sure.

I briefly tested the following cases to work correctly:
- Creating a response with an attachment
- Replacing a deferred response with a response containing an attachment
- Adding an attachment to an existing response
- Adding a second attachment to an existing response
- Removing an attachment from an existing response
- Replacing an attachment in an existing response

It might make sense to also use `CreateAttachment` in `MessageDetailedOpts`, which currently only allows attaching a single file. I will look into this when I get the chance.