### PR TITLE
Fully-General Attachments and Uploads

### DIFF
--- a/discord-haskell.cabal
+++ b/discord-haskell.cabal
@@ -115,6 +115,18 @@ executable state-counter
                      , unliftio
                      , discord-haskell
 
+executable attachments
+  main-is:             attachments.hs
+  default-language:    Haskell2010
+  ghc-options:         -Wall -fno-warn-type-defaults -fno-warn-unused-record-wildcards -threaded
+  hs-source-dirs:      examples
+  other-modules:
+    ExampleUtils
+  build-depends:       base
+                     , bytestring
+                     , text
+                     , discord-haskell
+
 library
   ghc-options:         -Wall -fno-warn-type-defaults -fno-warn-unused-record-wildcards
   hs-source-dirs:      src

--- a/examples/attachments.hs
+++ b/examples/attachments.hs
@@ -1,0 +1,82 @@
+{-# OPTIONS_GHC -Wno-incomplete-uni-patterns #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
+
+module Main (main) where
+
+import Control.Exception
+import Control.Concurrent
+import Control.Monad
+import Control.Monad.IO.Class
+import qualified Data.ByteString as B
+import qualified Data.Text.IO as T
+import Text.Printf
+import Discord
+import Discord.Types
+import Discord.Requests
+import Discord.Interactions
+import ExampleUtils
+
+call :: Request (r a) => FromJSON a => r a -> DiscordHandler a
+call = restCall >=> either (liftIO . throwIO) pure
+
+onEvent :: GuildId -> Event -> DiscordHandler ()
+onEvent guild event = do
+  liftIO $ putStrLn $ take 120 $ show event
+  case event of
+    Ready _ _ _ _ _ _ (PartialApplication app _) -> onReady app guild
+    InteractionCreate interaction -> onInteraction interaction
+    _ -> pure ()
+
+onReady :: ApplicationId -> GuildId -> DiscordHandler ()
+onReady app guild = call $ BulkOverWriteGuildApplicationCommand app guild [testCreate]
+
+onInteraction :: Interaction -> DiscordHandler ()
+onInteraction interaction = case interaction of
+    InteractionApplicationCommand {..} -> case applicationCommandData of
+        ApplicationCommandDataChatInput {..} -> case applicationCommandDataName of
+            "test" -> testHandle interactionApplicationId interactionId interactionToken
+            command -> fail $ printf "invalid command %s" $ show command
+        _ -> fail "invalid command data"
+    _ -> fail "invalid interaction"
+
+testCreate :: CreateApplicationCommand
+testCreate = CreateApplicationCommandChatInput "test" Nothing "test attachment actions" Nothing Nothing Nothing Nothing
+
+testHandle :: ApplicationId -> InteractionId -> InteractionToken -> DiscordHandler ()
+testHandle app interaction token = go where
+  go = do
+    message <- create
+    liftIO $ threadDelay 5000000
+    edit message
+  create = do
+    photo <- liftIO $ B.readFile "examples/embed-photo.jpg"
+    -- create a new response message with two uploads that get turned into attachments
+    let uploads = [
+          CreateUpload "test.txt" Nothing Nothing "this is a test file",
+          CreateUpload "test.jpg" Nothing Nothing photo]
+    let response = def {
+      interactionResponseMessageContent = Just "test",
+      interactionResponseMessageUploads = uploads }
+    call $ CreateInteractionResponse interaction token $ InteractionResponseChannelMessage response
+    call $ GetOriginalInteractionResponse app token
+  edit message = do
+    let [_textId, imageId] = attachmentId <$> messageAttachments message
+    -- drop the text attachment and retain the image attachment
+    let attachments = [CreateAttachment imageId Nothing Nothing Nothing]
+    -- upload a new file that gets added to the retained attachments
+    let uploads = [CreateUpload "test-new.txt" Nothing Nothing "this is another test file"]
+    let response = def {
+      interactionResponseMessageContent = Just "edited",
+      interactionResponseMessageAttachments = Just attachments,
+      interactionResponseMessageUploads = uploads }
+    void $ call $ EditOriginalInteractionResponse app token response
+
+main :: IO ()
+main = do
+  token <- getToken
+  guild <- getGuildId
+  let intent = def { gatewayIntentMessageContent = False }
+  let options = RunDiscordOpts token (pure ()) (pure ()) (onEvent guild) T.putStrLn False intent False
+  result <- runDiscord options
+  liftIO $ T.putStrLn result

--- a/src/Discord/Internal/Rest/Channel.hs
+++ b/src/Discord/Internal/Rest/Channel.hs
@@ -26,10 +26,8 @@ import Data.Aeson
 import Data.Default (Default, def)
 import Text.Emoji (emojiFromAlias)
 import qualified Data.Text as T
-import qualified Data.ByteString as B
 import qualified Data.ByteString.Lazy as BL
-import Network.HTTP.Client (RequestBody (RequestBodyBS))
-import Network.HTTP.Client.MultipartFormData (partFileRequestBody, partBS)
+import Network.HTTP.Client.MultipartFormData (partBS)
 import Network.HTTP.Req ((/:), (/~))
 import qualified Network.HTTP.Req as R
 
@@ -139,8 +137,10 @@ data MessageDetailedOpts = MessageDetailedOpts
     messageDetailedTTS                      :: Bool
   , -- | embedded rich content (up to 6000 characters)
     messageDetailedEmbeds                   :: Maybe [CreateEmbed]
-  , -- | the contents of the file being sent
-    messageDetailedFile                     :: Maybe (T.Text, B.ByteString)
+  , -- | metadata of existing attachments
+    messageDetailedAttachments              :: Maybe [CreateAttachment]
+  , -- | new uploads to attach to the message
+    messageDetailedUpload                   :: Maybe [CreateUpload]
   , -- | allowed mentions for the message
     messageDetailedAllowedMentions          :: Maybe AllowedMentions
   , -- | If `Just`, reply to the message referenced
@@ -155,7 +155,8 @@ instance Default MessageDetailedOpts where
   def = MessageDetailedOpts { messageDetailedContent         = ""
                             , messageDetailedTTS             = False
                             , messageDetailedEmbeds          = Nothing
-                            , messageDetailedFile            = Nothing
+                            , messageDetailedAttachments     = Nothing
+                            , messageDetailedUpload          = Nothing
                             , messageDetailedAllowedMentions = Nothing
                             , messageDetailedReference       = Nothing
                             , messageDetailedComponents      = Nothing
@@ -507,23 +508,16 @@ channelJsonRequest c = case c of
       in Post (channels /~ chan /: "messages") body mempty
 
   (CreateMessageDetailed chan msgOpts) ->
-    let fileUpload = messageDetailedFile msgOpts
-        filePart =
-          ( case fileUpload of
-              Nothing -> []
-              Just f ->
-                [ partFileRequestBody
-                    "file"
-                    (T.unpack $ fst f)
-                    (RequestBodyBS $ snd f)
-                ]
-          )
+    let fileAttachments = messageDetailedAttachments msgOpts
+        fileUpload = messageDetailedUpload msgOpts
+        filePart = maybe [] uploadsParts fileUpload
             ++ join (maybe [] (maybeEmbed . Just <$>) (messageDetailedEmbeds msgOpts))
 
         payloadData =  objectFromMaybes $
                         [ "content" .== messageDetailedContent msgOpts
                         , "tts"     .== messageDetailedTTS msgOpts ] ++
                         [ "embeds" .=? ((createEmbed <$>) <$> messageDetailedEmbeds msgOpts)
+                        , "attachments" .=? uploadsAdd fileUpload fileAttachments
                         , "allowed_mentions" .=? messageDetailedAllowedMentions msgOpts
                         , "message_reference" .=? messageDetailedReference msgOpts
                         , "components" .=? messageDetailedComponents msgOpts
@@ -562,23 +556,16 @@ channelJsonRequest c = case c of
 
   -- copied from CreateMessageDetailed, should be outsourced to function probably
   (EditMessage (chan, msg) msgOpts) ->
-    let fileUpload = messageDetailedFile msgOpts
-        filePart =
-          ( case fileUpload of
-              Nothing -> []
-              Just f ->
-                [ partFileRequestBody
-                    "file"
-                    (T.unpack $ fst f)
-                    (RequestBodyBS $ snd f)
-                ]
-          )
+    let fileAttachments = messageDetailedAttachments msgOpts
+        fileUpload = messageDetailedUpload msgOpts
+        filePart = maybe [] uploadsParts fileUpload
             ++ join (maybe [] (maybeEmbed . Just <$>) (messageDetailedEmbeds msgOpts))
 
         payloadData =  objectFromMaybes $
                         [ "content" .== messageDetailedContent msgOpts
                         , "tts"     .== messageDetailedTTS msgOpts ] ++
                         [ "embeds" .=? ((createEmbed <$>) <$> messageDetailedEmbeds msgOpts)
+                        , "attachments" .=? uploadsAdd fileUpload fileAttachments
                         , "allowed_mentions" .=? messageDetailedAllowedMentions msgOpts
                         , "message_reference" .=? messageDetailedReference msgOpts
                         , "components" .=? messageDetailedComponents msgOpts

--- a/src/Discord/Internal/Rest/Channel.hs
+++ b/src/Discord/Internal/Rest/Channel.hs
@@ -507,7 +507,7 @@ channelJsonRequest c = case c of
       in Post (channels /~ chan /: "messages") body mempty
 
   (CreateMessageDetailed chan msgOpts) ->
-    let uploads = uploadsAssemble (messageDetailedEmbeds msgOpts) (messageDetailedUpload msgOpts)
+    let uploads = uploadsAssemble (messageDetailedEmbeds msgOpts) ++ messageDetailedUpload msgOpts
         filePart = uploadsParts uploads
 
         payloadData =  objectFromMaybes $
@@ -553,7 +553,7 @@ channelJsonRequest c = case c of
 
   -- copied from CreateMessageDetailed, should be outsourced to function probably
   (EditMessage (chan, msg) msgOpts) ->
-    let uploads = uploadsAssemble (messageDetailedEmbeds msgOpts) (messageDetailedUpload msgOpts)
+    let uploads = uploadsAssemble (messageDetailedEmbeds msgOpts) ++ messageDetailedUpload msgOpts
         filePart = uploadsParts uploads
 
         payloadData =  objectFromMaybes $

--- a/src/Discord/Internal/Rest/Channel.hs
+++ b/src/Discord/Internal/Rest/Channel.hs
@@ -508,16 +508,14 @@ channelJsonRequest c = case c of
       in Post (channels /~ chan /: "messages") body mempty
 
   (CreateMessageDetailed chan msgOpts) ->
-    let fileAttachments = messageDetailedAttachments msgOpts
-        fileUpload = messageDetailedUpload msgOpts
-        filePart = maybe [] uploadsParts fileUpload
-            ++ join (maybe [] (maybeEmbed . Just <$>) (messageDetailedEmbeds msgOpts))
+    let uploads = uploadsAssemble $ messageDetailedUpload msgOpts
+        filePart = uploadsParts uploads ++ join (maybe [] (maybeEmbed . Just <$>) (messageDetailedEmbeds msgOpts))
 
         payloadData =  objectFromMaybes $
                         [ "content" .== messageDetailedContent msgOpts
                         , "tts"     .== messageDetailedTTS msgOpts ] ++
                         [ "embeds" .=? ((createEmbed <$>) <$> messageDetailedEmbeds msgOpts)
-                        , "attachments" .=? uploadsAdd fileUpload fileAttachments
+                        , "attachments" .=? uploadsAttachments uploads (messageDetailedAttachments msgOpts)
                         , "allowed_mentions" .=? messageDetailedAllowedMentions msgOpts
                         , "message_reference" .=? messageDetailedReference msgOpts
                         , "components" .=? messageDetailedComponents msgOpts
@@ -556,16 +554,14 @@ channelJsonRequest c = case c of
 
   -- copied from CreateMessageDetailed, should be outsourced to function probably
   (EditMessage (chan, msg) msgOpts) ->
-    let fileAttachments = messageDetailedAttachments msgOpts
-        fileUpload = messageDetailedUpload msgOpts
-        filePart = maybe [] uploadsParts fileUpload
-            ++ join (maybe [] (maybeEmbed . Just <$>) (messageDetailedEmbeds msgOpts))
+    let uploads = uploadsAssemble $ messageDetailedUpload msgOpts
+        filePart = uploadsParts uploads ++ join (maybe [] (maybeEmbed . Just <$>) (messageDetailedEmbeds msgOpts))
 
         payloadData =  objectFromMaybes $
                         [ "content" .== messageDetailedContent msgOpts
                         , "tts"     .== messageDetailedTTS msgOpts ] ++
                         [ "embeds" .=? ((createEmbed <$>) <$> messageDetailedEmbeds msgOpts)
-                        , "attachments" .=? uploadsAdd fileUpload fileAttachments
+                        , "attachments" .=? uploadsAttachments uploads (messageDetailedAttachments msgOpts)
                         , "allowed_mentions" .=? messageDetailedAllowedMentions msgOpts
                         , "message_reference" .=? messageDetailedReference msgOpts
                         , "components" .=? messageDetailedComponents msgOpts

--- a/src/Discord/Internal/Rest/Channel.hs
+++ b/src/Discord/Internal/Rest/Channel.hs
@@ -33,7 +33,6 @@ import qualified Network.HTTP.Req as R
 
 import Discord.Internal.Rest.Prelude
 import Discord.Internal.Types
-import Control.Monad (join)
 
 instance Request (ChannelRequest a) where
   majorRoute = channelMajorRoute
@@ -508,8 +507,8 @@ channelJsonRequest c = case c of
       in Post (channels /~ chan /: "messages") body mempty
 
   (CreateMessageDetailed chan msgOpts) ->
-    let uploads = uploadsAssemble $ messageDetailedUpload msgOpts
-        filePart = uploadsParts uploads ++ join (maybe [] (maybeEmbed . Just <$>) (messageDetailedEmbeds msgOpts))
+    let uploads = uploadsAssemble (messageDetailedEmbeds msgOpts) (messageDetailedUpload msgOpts)
+        filePart = uploadsParts uploads
 
         payloadData =  objectFromMaybes $
                         [ "content" .== messageDetailedContent msgOpts
@@ -554,8 +553,8 @@ channelJsonRequest c = case c of
 
   -- copied from CreateMessageDetailed, should be outsourced to function probably
   (EditMessage (chan, msg) msgOpts) ->
-    let uploads = uploadsAssemble $ messageDetailedUpload msgOpts
-        filePart = uploadsParts uploads ++ join (maybe [] (maybeEmbed . Just <$>) (messageDetailedEmbeds msgOpts))
+    let uploads = uploadsAssemble (messageDetailedEmbeds msgOpts) (messageDetailedUpload msgOpts)
+        filePart = uploadsParts uploads
 
         payloadData =  objectFromMaybes $
                         [ "content" .== messageDetailedContent msgOpts

--- a/src/Discord/Internal/Rest/Channel.hs
+++ b/src/Discord/Internal/Rest/Channel.hs
@@ -139,7 +139,7 @@ data MessageDetailedOpts = MessageDetailedOpts
   , -- | metadata of existing attachments
     messageDetailedAttachments              :: Maybe [CreateAttachment]
   , -- | new uploads to attach to the message
-    messageDetailedUpload                   :: Maybe [CreateUpload]
+    messageDetailedUpload                   :: [CreateUpload]
   , -- | allowed mentions for the message
     messageDetailedAllowedMentions          :: Maybe AllowedMentions
   , -- | If `Just`, reply to the message referenced
@@ -155,7 +155,7 @@ instance Default MessageDetailedOpts where
                             , messageDetailedTTS             = False
                             , messageDetailedEmbeds          = Nothing
                             , messageDetailedAttachments     = Nothing
-                            , messageDetailedUpload          = Nothing
+                            , messageDetailedUpload          = []
                             , messageDetailedAllowedMentions = Nothing
                             , messageDetailedReference       = Nothing
                             , messageDetailedComponents      = Nothing

--- a/src/Discord/Internal/Rest/Channel.hs
+++ b/src/Discord/Internal/Rest/Channel.hs
@@ -136,7 +136,7 @@ data MessageDetailedOpts = MessageDetailedOpts
     messageDetailedTTS                      :: Bool
   , -- | embedded rich content (up to 6000 characters)
     messageDetailedEmbeds                   :: Maybe [CreateEmbed]
-  , -- | metadata of existing attachments
+  , -- | Metadata of existing attachments. Metadata of new uploads will be added automatically.
     messageDetailedAttachments              :: Maybe [CreateAttachment]
   , -- | new uploads to attach to the message
     messageDetailedUpload                   :: [CreateUpload]

--- a/src/Discord/Internal/Rest/Channel.hs
+++ b/src/Discord/Internal/Rest/Channel.hs
@@ -507,7 +507,7 @@ channelJsonRequest c = case c of
       in Post (channels /~ chan /: "messages") body mempty
 
   (CreateMessageDetailed chan msgOpts) ->
-    let uploads = uploadsAssemble (messageDetailedEmbeds msgOpts) ++ messageDetailedUpload msgOpts
+    let uploads = uploadsEmbeds (messageDetailedEmbeds msgOpts) ++ messageDetailedUpload msgOpts
         filePart = uploadsParts uploads
 
         payloadData =  objectFromMaybes $
@@ -553,7 +553,7 @@ channelJsonRequest c = case c of
 
   -- copied from CreateMessageDetailed, should be outsourced to function probably
   (EditMessage (chan, msg) msgOpts) ->
-    let uploads = uploadsAssemble (messageDetailedEmbeds msgOpts) ++ messageDetailedUpload msgOpts
+    let uploads = uploadsEmbeds (messageDetailedEmbeds msgOpts) ++ messageDetailedUpload msgOpts
         filePart = uploadsParts uploads
 
         payloadData =  objectFromMaybes $

--- a/src/Discord/Internal/Rest/Interactions.hs
+++ b/src/Discord/Internal/Rest/Interactions.hs
@@ -85,4 +85,4 @@ interactionResponseJsonRequest a = case a of
     convertIRM :: InteractionResponseMessage -> RestIO R.ReqBodyMultipart
     convertIRM irm = R.reqBodyMultipart (partBS "payload_json" (BL.toStrict $ encode irm) : convert' irm)
     convert' :: InteractionResponseMessage -> [PartM IO]
-    convert' InteractionResponseMessage {..} = uploadsParts $ uploadsAssemble interactionResponseMessageEmbeds ++ interactionResponseMessageUploads
+    convert' InteractionResponseMessage {..} = uploadsParts $ uploadsEmbeds interactionResponseMessageEmbeds ++ interactionResponseMessageUploads

--- a/src/Discord/Internal/Rest/Interactions.hs
+++ b/src/Discord/Internal/Rest/Interactions.hs
@@ -85,8 +85,4 @@ interactionResponseJsonRequest a = case a of
     convertIRM :: InteractionResponseMessage -> RestIO R.ReqBodyMultipart
     convertIRM irm = R.reqBodyMultipart (partBS "payload_json" (BL.toStrict $ encode irm) : convert' irm)
     convert' :: InteractionResponseMessage -> [PartM IO]
-    convert' InteractionResponseMessage {..} = uploadsParts uploads ++ embeds where
-      uploads = uploadsAssemble interactionResponseMessageUploads
-      embeds = case interactionResponseMessageEmbeds of
-        Nothing -> []
-        Just f -> (maybeEmbed . Just) =<< f
+    convert' InteractionResponseMessage {..} = uploadsParts $ uploadsAssemble interactionResponseMessageEmbeds interactionResponseMessageUploads

--- a/src/Discord/Internal/Rest/Interactions.hs
+++ b/src/Discord/Internal/Rest/Interactions.hs
@@ -85,8 +85,8 @@ interactionResponseJsonRequest a = case a of
     convertIRM :: InteractionResponseMessage -> RestIO R.ReqBodyMultipart
     convertIRM irm = R.reqBodyMultipart (partBS "payload_json" (BL.toStrict $ encode irm) : convert' irm)
     convert' :: InteractionResponseMessage -> [PartM IO]
-    convert' InteractionResponseMessage {..} = uploads ++ embeds where
-      uploads = maybe [] uploadsParts interactionResponseMessageUploads
+    convert' InteractionResponseMessage {..} = uploadsParts uploads ++ embeds where
+      uploads = uploadsAssemble interactionResponseMessageUploads
       embeds = case interactionResponseMessageEmbeds of
         Nothing -> []
         Just f -> (maybeEmbed . Just) =<< f

--- a/src/Discord/Internal/Rest/Interactions.hs
+++ b/src/Discord/Internal/Rest/Interactions.hs
@@ -85,4 +85,4 @@ interactionResponseJsonRequest a = case a of
     convertIRM :: InteractionResponseMessage -> RestIO R.ReqBodyMultipart
     convertIRM irm = R.reqBodyMultipart (partBS "payload_json" (BL.toStrict $ encode irm) : convert' irm)
     convert' :: InteractionResponseMessage -> [PartM IO]
-    convert' InteractionResponseMessage {..} = uploadsParts $ uploadsAssemble interactionResponseMessageEmbeds interactionResponseMessageUploads
+    convert' InteractionResponseMessage {..} = uploadsParts $ uploadsAssemble interactionResponseMessageEmbeds ++ interactionResponseMessageUploads

--- a/src/Discord/Internal/Rest/Interactions.hs
+++ b/src/Discord/Internal/Rest/Interactions.hs
@@ -85,6 +85,8 @@ interactionResponseJsonRequest a = case a of
     convertIRM :: InteractionResponseMessage -> RestIO R.ReqBodyMultipart
     convertIRM irm = R.reqBodyMultipart (partBS "payload_json" (BL.toStrict $ encode irm) : convert' irm)
     convert' :: InteractionResponseMessage -> [PartM IO]
-    convert' InteractionResponseMessage {..} = case interactionResponseMessageEmbeds of
-      Nothing -> []
-      Just f -> (maybeEmbed . Just) =<< f
+    convert' InteractionResponseMessage {..} = uploads ++ embeds where
+      uploads = maybe [] uploadsParts interactionResponseMessageUploads
+      embeds = case interactionResponseMessageEmbeds of
+        Nothing -> []
+        Just f -> (maybeEmbed . Just) =<< f

--- a/src/Discord/Internal/Types/Channel.hs
+++ b/src/Discord/Internal/Types/Channel.hs
@@ -18,7 +18,7 @@ module Discord.Internal.Types.Channel (
   , Attachment (..)
   , CreateAttachment (..)
   , CreateUpload (..)
-  , uploadsAssemble
+  , uploadsEmbeds
   , uploadsAttachments
   , uploadsParts
   , Nonce (..)
@@ -763,8 +763,8 @@ uploadsEmbed CreateEmbed {..} = catMaybes [author, thumbnail, image, footer] whe
   go name (CreateEmbedImageUpload dat) = Just $ CreateUpload (prefix <> name) Nothing Nothing dat
   prefix = T.filter (/= ' ') createEmbedTitle
 
-uploadsAssemble :: Maybe [CreateEmbed] -> [CreateUpload]
-uploadsAssemble = maybe [] $ concatMap uploadsEmbed
+uploadsEmbeds :: Maybe [CreateEmbed] -> [CreateUpload]
+uploadsEmbeds = maybe [] $ concatMap uploadsEmbed
 
 uploadsEntries :: [CreateUpload] -> [CreateAttachment]
 uploadsEntries = zipWith go [0 ..] where

--- a/src/Discord/Internal/Types/Channel.hs
+++ b/src/Discord/Internal/Types/Channel.hs
@@ -18,7 +18,8 @@ module Discord.Internal.Types.Channel (
   , Attachment (..)
   , CreateAttachment (..)
   , CreateUpload (..)
-  , uploadsAdd
+  , uploadsAssemble
+  , uploadsAttachments
   , uploadsParts
   , Nonce (..)
   , MessageReference (..)
@@ -732,17 +733,17 @@ data CreateUpload = CreateUpload
   , uploadContent :: ByteString
   } deriving (Show, Read, Eq, Ord)
 
-uploadsAttachments :: [CreateUpload] -> [CreateAttachment]
-uploadsAttachments = zipWith go [0 ..] where
+uploadsAssemble :: Maybe [CreateUpload] -> [CreateUpload]
+uploadsAssemble = fromMaybe []
+
+uploadsAttachments :: [CreateUpload] -> Maybe [CreateAttachment] -> Maybe [CreateAttachment]
+uploadsAttachments uploads attachments = if null entries then Nothing else Just entries where
+  entries = entriesUploads ++ entriesAttachments
+  entriesUploads = zipWith go [0 ..] uploads
+  entriesAttachments = fromMaybe [] attachments
   go index CreateUpload {..} = CreateAttachment identifier filename uploadTitle uploadDescription where
     identifier = DiscordId $ Snowflake index
     filename = Just uploadFilename
-
-uploadsAdd :: Maybe [CreateUpload] -> Maybe [CreateAttachment] -> Maybe [CreateAttachment]
-uploadsAdd uploads attachments = if null entries then Nothing else Just entries where
-  entries = entriesUploads ++ entriesAttachments
-  entriesUploads = maybe [] uploadsAttachments uploads
-  entriesAttachments = fromMaybe [] attachments
 
 uploadsParts :: [CreateUpload] -> [Part]
 uploadsParts = zipWith go [0 ..] where

--- a/src/Discord/Internal/Types/Channel.hs
+++ b/src/Discord/Internal/Types/Channel.hs
@@ -746,14 +746,17 @@ uploadsEmbed CreateEmbed {..} = catMaybes [author, thumbnail, image, footer] whe
 uploadsAssemble :: Maybe [CreateEmbed] -> [CreateUpload] -> [CreateUpload]
 uploadsAssemble embeds = (++) $ maybe [] (concatMap uploadsEmbed) embeds
 
-uploadsAttachments :: [CreateUpload] -> Maybe [CreateAttachment] -> Maybe [CreateAttachment]
-uploadsAttachments uploads attachments = if null entries then Nothing else Just entries where
-  entries = entriesUploads ++ entriesAttachments
-  entriesUploads = zipWith go [0 ..] uploads
-  entriesAttachments = fromMaybe [] attachments
+uploadsEntries :: [CreateUpload] -> [CreateAttachment]
+uploadsEntries = zipWith go [0 ..] where
   go index CreateUpload {..} = CreateAttachment identifier filename uploadTitle uploadDescription where
     identifier = DiscordId $ Snowflake index
     filename = Just uploadFilename
+
+uploadsAttachments :: [CreateUpload] -> Maybe [CreateAttachment] -> Maybe [CreateAttachment]
+uploadsAttachments uploads attachments = if null entries then Nothing else Just entries where
+  entries = entriesUploads ++ entriesAttachments
+  entriesUploads = uploadsEntries uploads
+  entriesAttachments = fromMaybe [] attachments
 
 uploadsParts :: [CreateUpload] -> [Part]
 uploadsParts = zipWith go [0 ..] where

--- a/src/Discord/Internal/Types/Channel.hs
+++ b/src/Discord/Internal/Types/Channel.hs
@@ -750,6 +750,9 @@ data CreateUpload = CreateUpload
   , uploadContent :: ByteString
   } deriving (Show, Read, Eq, Ord)
 
+-- creates potentially ambiguous attachment urls
+-- in accordance with what Discord.Internal.Types.Embed.createEmbed expects
+-- see https://github.com/discord-haskell/discord-haskell/issues/249
 uploadsEmbed :: CreateEmbed -> [CreateUpload]
 uploadsEmbed CreateEmbed {..} = catMaybes [author, thumbnail, image, footer] where
   author = createEmbedAuthorIcon >>= go "author.png"

--- a/src/Discord/Internal/Types/Channel.hs
+++ b/src/Discord/Internal/Types/Channel.hs
@@ -679,7 +679,10 @@ instance ToJSON MessageReaction where
       , "emoji" .== messageReactionEmoji
       ]
 
--- | Represents an attached to a message file.
+-- | Metadata of a message attachment in a response from the Discord API.
+-- This type is used when retrieving existing attachments.
+--
+-- Reference: https://docs.discord.com/developers/resources/message#attachment-object
 data Attachment = Attachment
   { attachmentId       :: AttachmentId     -- ^ Attachment id
   , attachmentFilename :: T.Text        -- ^ Name of attached file
@@ -711,6 +714,16 @@ instance ToJSON Attachment where
       , "width" .=? attachmentWidth
       ]
 
+-- | Metadata of a message attachment in a request to the Discord API.
+-- This type is used when creating or editing messages to specify attachments to be added or retained.
+--
+-- When using a `CreateUpload` value for new uploads, corresponding `CreateAttachment` values are added automatically.
+-- When referring to existing attachments, they should use the `attachmentId`
+-- of the corresponding `Attachment` value of the existing attachment.
+--
+-- Discord calls this a "partial attachment object".
+-- It is briefly mentioned at https://docs.discord.com/developers/resources/message#message-call-object.
+-- Some examples are shown at https://docs.discord.com/developers/reference#uploading-files.
 data CreateAttachment = CreateAttachment
   { createAttachmentId :: AttachmentId
   , createAttachmentFilename :: Maybe Text
@@ -726,6 +739,10 @@ instance ToJSON CreateAttachment where
     , "description" .=? createAttachmentDescription
     ]
 
+-- | Data and metadata for a file to be uploaded to Discord.
+-- This type is used when creating or editing messages to specify new files to be turned into attachments.
+--
+-- Reference: https://docs.discord.com/developers/reference#uploading-files
 data CreateUpload = CreateUpload
   { uploadFilename :: Text
   , uploadTitle :: Maybe Text

--- a/src/Discord/Internal/Types/Channel.hs
+++ b/src/Discord/Internal/Types/Channel.hs
@@ -747,7 +747,7 @@ uploadsAdd uploads attachments = if null entries then Nothing else Just entries 
 uploadsParts :: [CreateUpload] -> [Part]
 uploadsParts = zipWith go [0 ..] where
   go index CreateUpload {..} = partFileRequestBody name path body where
-    name = T.pack $ printf "files[%d]" index
+    name = T.pack $ printf "files[%d]" (index :: Int)
     path = T.unpack uploadFilename
     body = RequestBodyBS uploadContent
 

--- a/src/Discord/Internal/Types/Channel.hs
+++ b/src/Discord/Internal/Types/Channel.hs
@@ -16,6 +16,10 @@ module Discord.Internal.Types.Channel (
   , AllowedMentions (..)
   , MessageReaction (..)
   , Attachment (..)
+  , CreateAttachment (..)
+  , CreateUpload (..)
+  , uploadsAdd
+  , uploadsParts
   , Nonce (..)
   , MessageReference (..)
   , MessageType (..)
@@ -29,14 +33,19 @@ module Discord.Internal.Types.Channel (
   ) where
 
 import Control.Applicative (empty)
+import Data.Maybe
 import Data.Aeson
 import Data.Aeson.Types (Parser)
 import Data.Default (Default, def)
+import Data.ByteString (ByteString)
 import Data.Text (Text)
 import Data.Time.Clock
 import qualified Data.Text as T
 import Data.Bits
 import Data.Data (Data)
+import Text.Printf
+import Network.HTTP.Client
+import Network.HTTP.Client.MultipartFormData
 
 import Discord.Internal.Types.Prelude
 import Discord.Internal.Types.User (User(..), GuildMember)
@@ -700,6 +709,47 @@ instance ToJSON Attachment where
       , "height" .=? attachmentHeight
       , "width" .=? attachmentWidth
       ]
+
+data CreateAttachment = CreateAttachment
+  { createAttachmentId :: AttachmentId
+  , createAttachmentFilename :: Maybe Text
+  , createAttachmentTitle :: Maybe Text
+  , createAttachmentDescription :: Maybe Text
+  } deriving (Show, Read, Eq, Ord)
+
+instance ToJSON CreateAttachment where
+  toJSON CreateAttachment {..} = objectFromMaybes
+    [ "id" .== createAttachmentId
+    , "filename" .=? createAttachmentFilename
+    , "title" .=? createAttachmentTitle
+    , "description" .=? createAttachmentDescription
+    ]
+
+data CreateUpload = CreateUpload
+  { uploadFilename :: Text
+  , uploadTitle :: Maybe Text
+  , uploadDescription :: Maybe Text
+  , uploadContent :: ByteString
+  } deriving (Show, Read, Eq, Ord)
+
+uploadsAttachments :: [CreateUpload] -> [CreateAttachment]
+uploadsAttachments = zipWith go [0 ..] where
+  go index CreateUpload {..} = CreateAttachment identifier filename uploadTitle uploadDescription where
+    identifier = DiscordId $ Snowflake index
+    filename = Just uploadFilename
+
+uploadsAdd :: Maybe [CreateUpload] -> Maybe [CreateAttachment] -> Maybe [CreateAttachment]
+uploadsAdd uploads attachments = if null entries then Nothing else Just entries where
+  entries = entriesUploads ++ entriesAttachments
+  entriesUploads = maybe [] uploadsAttachments uploads
+  entriesAttachments = fromMaybe [] attachments
+
+uploadsParts :: [CreateUpload] -> [Part]
+uploadsParts = zipWith go [0 ..] where
+  go index CreateUpload {..} = partFileRequestBody name path body where
+    name = T.pack $ printf "files[%d]" index
+    path = T.unpack uploadFilename
+    body = RequestBodyBS uploadContent
 
 newtype Nonce = Nonce T.Text
   deriving (Show, Read, Eq, Ord)

--- a/src/Discord/Internal/Types/Channel.hs
+++ b/src/Discord/Internal/Types/Channel.hs
@@ -733,8 +733,20 @@ data CreateUpload = CreateUpload
   , uploadContent :: ByteString
   } deriving (Show, Read, Eq, Ord)
 
-uploadsAssemble :: Maybe [CreateUpload] -> [CreateUpload]
-uploadsAssemble = fromMaybe []
+uploadsEmbed :: CreateEmbed -> [CreateUpload]
+uploadsEmbed CreateEmbed {..} = catMaybes [author, thumbnail, image, footer] where
+  author = createEmbedAuthorIcon >>= go "author.png"
+  thumbnail = createEmbedThumbnail >>= go "thumbnail.png"
+  image = createEmbedImage >>= go "image.png"
+  footer = createEmbedFooterIcon >>= go "footer.png"
+  go _ (CreateEmbedImageUrl _) = Nothing
+  go name (CreateEmbedImageUpload dat) = Just $ CreateUpload (prefix <> name) Nothing Nothing dat
+  prefix = T.filter (/= ' ') createEmbedTitle
+
+uploadsAssemble :: Maybe [CreateEmbed] -> Maybe [CreateUpload] -> [CreateUpload]
+uploadsAssemble embeds uploads = entriesEmbeds ++ entriesUploads where
+  entriesEmbeds = maybe [] (concatMap uploadsEmbed) embeds
+  entriesUploads = fromMaybe [] uploads
 
 uploadsAttachments :: [CreateUpload] -> Maybe [CreateAttachment] -> Maybe [CreateAttachment]
 uploadsAttachments uploads attachments = if null entries then Nothing else Just entries where

--- a/src/Discord/Internal/Types/Channel.hs
+++ b/src/Discord/Internal/Types/Channel.hs
@@ -743,10 +743,8 @@ uploadsEmbed CreateEmbed {..} = catMaybes [author, thumbnail, image, footer] whe
   go name (CreateEmbedImageUpload dat) = Just $ CreateUpload (prefix <> name) Nothing Nothing dat
   prefix = T.filter (/= ' ') createEmbedTitle
 
-uploadsAssemble :: Maybe [CreateEmbed] -> Maybe [CreateUpload] -> [CreateUpload]
-uploadsAssemble embeds uploads = entriesEmbeds ++ entriesUploads where
-  entriesEmbeds = maybe [] (concatMap uploadsEmbed) embeds
-  entriesUploads = fromMaybe [] uploads
+uploadsAssemble :: Maybe [CreateEmbed] -> [CreateUpload] -> [CreateUpload]
+uploadsAssemble embeds = (++) $ maybe [] (concatMap uploadsEmbed) embeds
 
 uploadsAttachments :: [CreateUpload] -> Maybe [CreateAttachment] -> Maybe [CreateAttachment]
 uploadsAttachments uploads attachments = if null entries then Nothing else Just entries where

--- a/src/Discord/Internal/Types/Channel.hs
+++ b/src/Discord/Internal/Types/Channel.hs
@@ -763,8 +763,8 @@ uploadsEmbed CreateEmbed {..} = catMaybes [author, thumbnail, image, footer] whe
   go name (CreateEmbedImageUpload dat) = Just $ CreateUpload (prefix <> name) Nothing Nothing dat
   prefix = T.filter (/= ' ') createEmbedTitle
 
-uploadsAssemble :: Maybe [CreateEmbed] -> [CreateUpload] -> [CreateUpload]
-uploadsAssemble embeds = (++) $ maybe [] (concatMap uploadsEmbed) embeds
+uploadsAssemble :: Maybe [CreateEmbed] -> [CreateUpload]
+uploadsAssemble = maybe [] $ concatMap uploadsEmbed
 
 uploadsEntries :: [CreateUpload] -> [CreateAttachment]
 uploadsEntries = zipWith go [0 ..] where

--- a/src/Discord/Internal/Types/Channel.hs
+++ b/src/Discord/Internal/Types/Channel.hs
@@ -753,10 +753,8 @@ uploadsEntries = zipWith go [0 ..] where
     filename = Just uploadFilename
 
 uploadsAttachments :: [CreateUpload] -> Maybe [CreateAttachment] -> Maybe [CreateAttachment]
-uploadsAttachments uploads attachments = if null entries then Nothing else Just entries where
-  entries = entriesUploads ++ entriesAttachments
-  entriesUploads = uploadsEntries uploads
-  entriesAttachments = fromMaybe [] attachments
+uploadsAttachments [] attachments = attachments
+uploadsAttachments uploads attachments = Just $ uploadsEntries uploads ++ fromMaybe [] attachments
 
 uploadsParts :: [CreateUpload] -> [Part]
 uploadsParts = zipWith go [0 ..] where

--- a/src/Discord/Internal/Types/Embed.hs
+++ b/src/Discord/Internal/Types/Embed.hs
@@ -12,9 +12,6 @@ import qualified Data.Text as T
 import qualified Data.ByteString as B
 import Data.Functor ((<&>))
 
-import Network.HTTP.Client.MultipartFormData (PartM, partFileRequestBody)
-import Network.HTTP.Client (RequestBody(RequestBodyBS))
-
 import Discord.Internal.Types.Color (DiscordColor)
 
 createEmbed :: CreateEmbed -> Embed
@@ -271,14 +268,3 @@ instance FromJSON EmbedField where
     EmbedField <$> o .:  "name"
                <*> o .:  "value"
                <*> o .:? "inline"
-
-
-maybeEmbed :: Maybe CreateEmbed -> [PartM IO]
-maybeEmbed =
-      let mkPart (name,content) = partFileRequestBody name (T.unpack name) (RequestBodyBS content)
-          uploads CreateEmbed{..} = [(T.filter (/=' ') $ createEmbedTitle<>n,c) | (n, Just (CreateEmbedImageUpload c)) <-
-                                          [ ("author.png", createEmbedAuthorIcon)
-                                          , ("thumbnail.png", createEmbedThumbnail)
-                                          , ("image.png", createEmbedImage)
-                                          , ("footer.png", createEmbedFooterIcon) ]]
-      in maybe [] (map mkPart . uploads)

--- a/src/Discord/Internal/Types/Interactions.hs
+++ b/src/Discord/Internal/Types/Interactions.hs
@@ -638,17 +638,17 @@ data InteractionResponseMessage = InteractionResponseMessage
     interactionResponseMessageFlags :: Maybe InteractionResponseMessageFlags,
     interactionResponseMessageComponents :: Maybe [ActionRow],
     interactionResponseMessageAttachments :: Maybe [CreateAttachment],
-    interactionResponseMessageUploads :: Maybe [CreateUpload]
+    interactionResponseMessageUploads :: [CreateUpload]
   }
   deriving (Show, Read, Eq, Ord)
 
 -- | A basic interaction response, sending back the given text. This is
 -- effectively a helper function.
 interactionResponseMessageBasic :: T.Text -> InteractionResponseMessage
-interactionResponseMessageBasic t = InteractionResponseMessage Nothing (Just t) Nothing Nothing Nothing Nothing Nothing Nothing
+interactionResponseMessageBasic t = InteractionResponseMessage Nothing (Just t) Nothing Nothing Nothing Nothing Nothing []
 
 instance Default InteractionResponseMessage where
-  def = InteractionResponseMessage Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing
+  def = InteractionResponseMessage Nothing Nothing Nothing Nothing Nothing Nothing Nothing []
 
 instance ToJSON InteractionResponseMessage where
   toJSON InteractionResponseMessage {..} =

--- a/src/Discord/Internal/Types/Interactions.hs
+++ b/src/Discord/Internal/Types/Interactions.hs
@@ -41,7 +41,7 @@ import Data.Bits (Bits (shift, (.|.)))
 import Data.Foldable (Foldable (toList))
 import qualified Data.Text as T
 import Discord.Internal.Types.ApplicationCommands (Choice, Number)
-import Discord.Internal.Types.Channel (AllowedMentions, CreateAttachment, CreateUpload, uploadsAdd, Message)
+import Discord.Internal.Types.Channel (AllowedMentions, CreateAttachment, CreateUpload, uploadsAssemble, uploadsAttachments, Message)
 import Discord.Internal.Types.Components (ActionRow, TextInput)
 import Discord.Internal.Types.Embed (CreateEmbed, createEmbed)
 import Discord.Internal.Types.Prelude (ApplicationCommandId, ApplicationId, ChannelId, GuildId, InteractionId, InteractionToken, MessageId, RoleId, Snowflake, UserId, objectFromMaybes, (.=?))
@@ -659,8 +659,9 @@ instance ToJSON InteractionResponseMessage where
         "allowed_mentions" .=? interactionResponseMessageAllowedMentions,
         "flags" .=? interactionResponseMessageFlags,
         "components" .=? interactionResponseMessageComponents,
-        "attachments" .=? uploadsAdd interactionResponseMessageUploads interactionResponseMessageAttachments
+        "attachments" .=? uploadsAttachments uploads interactionResponseMessageAttachments
       ]
+    where uploads = uploadsAssemble interactionResponseMessageUploads
 
 -- | Types of flags to attach to the interaction message.
 --

--- a/src/Discord/Internal/Types/Interactions.hs
+++ b/src/Discord/Internal/Types/Interactions.hs
@@ -41,7 +41,7 @@ import Data.Bits (Bits (shift, (.|.)))
 import Data.Foldable (Foldable (toList))
 import qualified Data.Text as T
 import Discord.Internal.Types.ApplicationCommands (Choice, Number)
-import Discord.Internal.Types.Channel (AllowedMentions, CreateAttachment, CreateUpload, uploadsAssemble, uploadsAttachments, Message)
+import Discord.Internal.Types.Channel (AllowedMentions, CreateAttachment, CreateUpload, uploadsEmbeds, uploadsAttachments, Message)
 import Discord.Internal.Types.Components (ActionRow, TextInput)
 import Discord.Internal.Types.Embed (CreateEmbed, createEmbed)
 import Discord.Internal.Types.Prelude (ApplicationCommandId, ApplicationId, ChannelId, GuildId, InteractionId, InteractionToken, MessageId, RoleId, Snowflake, UserId, objectFromMaybes, (.=?))
@@ -661,7 +661,7 @@ instance ToJSON InteractionResponseMessage where
         "components" .=? interactionResponseMessageComponents,
         "attachments" .=? uploadsAttachments uploads interactionResponseMessageAttachments
       ]
-    where uploads = uploadsAssemble interactionResponseMessageEmbeds ++ interactionResponseMessageUploads
+    where uploads = uploadsEmbeds interactionResponseMessageEmbeds ++ interactionResponseMessageUploads
 
 -- | Types of flags to attach to the interaction message.
 --

--- a/src/Discord/Internal/Types/Interactions.hs
+++ b/src/Discord/Internal/Types/Interactions.hs
@@ -661,7 +661,7 @@ instance ToJSON InteractionResponseMessage where
         "components" .=? interactionResponseMessageComponents,
         "attachments" .=? uploadsAttachments uploads interactionResponseMessageAttachments
       ]
-    where uploads = uploadsAssemble interactionResponseMessageUploads
+    where uploads = uploadsAssemble interactionResponseMessageEmbeds interactionResponseMessageUploads
 
 -- | Types of flags to attach to the interaction message.
 --

--- a/src/Discord/Internal/Types/Interactions.hs
+++ b/src/Discord/Internal/Types/Interactions.hs
@@ -41,7 +41,7 @@ import Data.Bits (Bits (shift, (.|.)))
 import Data.Foldable (Foldable (toList))
 import qualified Data.Text as T
 import Discord.Internal.Types.ApplicationCommands (Choice, Number)
-import Discord.Internal.Types.Channel (AllowedMentions, Attachment, Message)
+import Discord.Internal.Types.Channel (AllowedMentions, CreateAttachment, CreateUpload, uploadsAdd, Message)
 import Discord.Internal.Types.Components (ActionRow, TextInput)
 import Discord.Internal.Types.Embed (CreateEmbed, createEmbed)
 import Discord.Internal.Types.Prelude (ApplicationCommandId, ApplicationId, ChannelId, GuildId, InteractionId, InteractionToken, MessageId, RoleId, Snowflake, UserId, objectFromMaybes, (.=?))
@@ -637,17 +637,18 @@ data InteractionResponseMessage = InteractionResponseMessage
     interactionResponseMessageAllowedMentions :: Maybe AllowedMentions,
     interactionResponseMessageFlags :: Maybe InteractionResponseMessageFlags,
     interactionResponseMessageComponents :: Maybe [ActionRow],
-    interactionResponseMessageAttachments :: Maybe [Attachment]
+    interactionResponseMessageAttachments :: Maybe [CreateAttachment],
+    interactionResponseMessageUploads :: Maybe [CreateUpload]
   }
   deriving (Show, Read, Eq, Ord)
 
 -- | A basic interaction response, sending back the given text. This is
 -- effectively a helper function.
 interactionResponseMessageBasic :: T.Text -> InteractionResponseMessage
-interactionResponseMessageBasic t = InteractionResponseMessage Nothing (Just t) Nothing Nothing Nothing Nothing Nothing
+interactionResponseMessageBasic t = InteractionResponseMessage Nothing (Just t) Nothing Nothing Nothing Nothing Nothing Nothing
 
 instance Default InteractionResponseMessage where
-  def = InteractionResponseMessage Nothing Nothing Nothing Nothing Nothing Nothing Nothing
+  def = InteractionResponseMessage Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing
 
 instance ToJSON InteractionResponseMessage where
   toJSON InteractionResponseMessage {..} =
@@ -658,7 +659,7 @@ instance ToJSON InteractionResponseMessage where
         "allowed_mentions" .=? interactionResponseMessageAllowedMentions,
         "flags" .=? interactionResponseMessageFlags,
         "components" .=? interactionResponseMessageComponents,
-        "attachments" .=? interactionResponseMessageAttachments
+        "attachments" .=? uploadsAdd interactionResponseMessageUploads interactionResponseMessageAttachments
       ]
 
 -- | Types of flags to attach to the interaction message.

--- a/src/Discord/Internal/Types/Interactions.hs
+++ b/src/Discord/Internal/Types/Interactions.hs
@@ -661,7 +661,7 @@ instance ToJSON InteractionResponseMessage where
         "components" .=? interactionResponseMessageComponents,
         "attachments" .=? uploadsAttachments uploads interactionResponseMessageAttachments
       ]
-    where uploads = uploadsAssemble interactionResponseMessageEmbeds interactionResponseMessageUploads
+    where uploads = uploadsAssemble interactionResponseMessageEmbeds ++ interactionResponseMessageUploads
 
 -- | Types of flags to attach to the interaction message.
 --


### PR DESCRIPTION
Guiding principle: A motivated user should be able to do anything the Discord API allows.

I considered the following example scenarios to guide the design:
1. Adding/removing some attachments to/from a message while keeping existing attachments intact without reuploading them.
2. Using the same attachment in multiple places (for example, author icon of multiple embeds) within the same message.

So far, this draft enables:
- Adding an arbitrary number of attachments to regular messages (used to be restricted to a single attachment)
- Adding an arbitrary number of attachments to interaction responses (used to be impossible)
- Adding and removing attachments from existing messages without reuploading existing files
- Fixing #232

It is worth noting that it achieves this without burdening the user with managing Discord's numeric file indices (`files[n]`). When uploading an attachment, the user only needs to provide a filename and the data.

This PR supersedes #240.

# `CreateEmbed`

The question that remains is how to deal with the existing `CreateEmbed` infrastructure. High-level pseudocode:
```hs
data CreateEmbed = CreateEmbed {
    title :: Text,
    image :: ByteString }

data CreateUpload = CreateUpload {
    filename :: Text,
    content :: ByteString }

data Message = Message {
    content :: Text,
    embeds :: [CreateEmbed],
    uploads :: [CreateUpload] }
```
`CreateEmbed` allows adding images to embeds by specifying them at the embed level directly as values. This makes (2) impossible, since there is no way of referencing attachments, which fundamentally exist at the level of messages, not at the level of individual embeds.

With the preliminary work in this draft, it would be very easy to replace the `image :: ByteString` with `image :: Text` and ask the user to reference their attachments via Discord's `attachment://upload.png` syntax. The user would then be responsible for managing the attachments at the message level and referencing them in each embed, giving them access to the full flexibility that the API exposes. This would also fix the disambiguation bug that currently exists when multiple embeds with the same title are added to the same message. It is even possible that this would make the entire `CreateEmbed` type obsolete, since it would then be nearly identical to `Embed` itself.

This would be my preferred way of doing things. However, it would be a breaking change for existing users of the `CreateEmbed` functionality. I have not spent too much time thinking about ways of preserving the `CreateEmbed` functionality, but I think it will be quite difficult to do so while also giving access to the new functionality in a consistent way.