### PR TITLE
Use Specific Type for `resolvedDataAttachments`

### DIFF
--- a/src/Discord/Internal/Types/Guild.hs
+++ b/src/Discord/Internal/Types/Guild.hs
@@ -297,6 +297,17 @@ data Role =
       , roleMention :: Bool                      -- ^ Whether this role is mentionable
     } deriving (Show, Read, Eq, Ord)
 
+instance ToJSON Role where
+  toJSON Role {..} = object
+    [ "id" .= roleId
+    , "name" .= roleName
+    , "color" .= roleColor
+    , "hoist" .= roleHoist
+    , "position" .= rolePos
+    , "permissions" .= rolePerms
+    , "managed" .= roleManaged
+    , "mentionable" .= roleMention
+    ]
 instance FromJSON Role where
   parseJSON = withObject "Role" $ \o ->
     Role <$> o .: "id"

--- a/src/Discord/Internal/Types/Interactions.hs
+++ b/src/Discord/Internal/Types/Interactions.hs
@@ -35,6 +35,7 @@ where
 import Control.Applicative (Alternative ((<|>)))
 import Control.Monad (join)
 import Data.Default
+import Data.Map (Map)
 import Data.Aeson
 import Data.Aeson.Types (Parser)
 import Data.Bits (Bits (shift, (.|.)))
@@ -542,7 +543,7 @@ data ResolvedData = ResolvedData
     resolvedDataRoles :: Maybe Value,
     resolvedDataChannels :: Maybe Value,
     resolvedDataMessages :: Maybe Value,
-    resolvedDataAttachments :: Maybe Value
+    resolvedDataAttachments :: Maybe (Map Snowflake Attachment)
   }
   deriving (Show, Read, Eq, Ord)
 

--- a/src/Discord/Internal/Types/Interactions.hs
+++ b/src/Discord/Internal/Types/Interactions.hs
@@ -47,6 +47,7 @@ import Discord.Internal.Types.Components (ActionRow, TextInput)
 import Discord.Internal.Types.Embed (CreateEmbed, createEmbed)
 import Discord.Internal.Types.Prelude (ApplicationCommandId, ApplicationId, ChannelId, GuildId, InteractionId, InteractionToken, MessageId, RoleId, Snowflake, UserId, objectFromMaybes, (.=?))
 import Discord.Internal.Types.User (GuildMember, User)
+import Discord.Internal.Types.Guild (Role)
 
 -- | An interaction received from discord.
 data Interaction
@@ -538,11 +539,11 @@ parseValue o False = Right <$> o .: "value"
 --
 -- https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-resolved-data-structure
 data ResolvedData = ResolvedData
-  { resolvedDataUsers :: Maybe Value,
-    resolvedDataMembers :: Maybe Value,
-    resolvedDataRoles :: Maybe Value,
-    resolvedDataChannels :: Maybe Value,
-    resolvedDataMessages :: Maybe Value,
+  { resolvedDataUsers :: Maybe (Map Snowflake User),
+    resolvedDataMembers :: Maybe (Map Snowflake Value),
+    resolvedDataRoles :: Maybe (Map Snowflake Role),
+    resolvedDataChannels :: Maybe (Map Snowflake Value),
+    resolvedDataMessages :: Maybe (Map Snowflake Message),
     resolvedDataAttachments :: Maybe (Map Snowflake Attachment)
   }
   deriving (Show, Read, Eq, Ord)


### PR DESCRIPTION
According to the [documentation](https://docs.discord.com/developers/interactions/receiving-and-responding#interaction-object), this field is a "Map of Snowflakes to attachment objects", so we can parse this into a more specific type.

I tested it briefly and it seems to work for its intended use case of attachment parameters to chat input application commands.